### PR TITLE
feat(rt): add TokioExecutor

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,5 +5,6 @@ pub use crate::error::{GenericError, Result};
 
 pub mod client;
 pub mod common;
+pub mod rt;
 
 mod error;

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -1,0 +1,4 @@
+//! Runtime utilities
+
+/// Implementation of [`hyper::rt::Executor`] that utilises [`tokio::spawn`].
+pub mod tokio_executor;

--- a/src/rt/tokio_executor.rs
+++ b/src/rt/tokio_executor.rs
@@ -1,0 +1,42 @@
+use hyper::rt::Executor;
+use std::future::Future;
+
+/// Future executor that utilises `tokio` threads.
+#[non_exhaustive]
+#[derive(Default, Debug)]
+pub struct TokioExecutor {}
+
+impl<Fut> Executor<Fut> for TokioExecutor
+where
+    Fut: Future + Send + 'static,
+    Fut::Output: Send + 'static,
+{
+    fn execute(&self, fut: Fut) {
+        tokio::spawn(fut);
+    }
+}
+
+impl TokioExecutor {
+    /// Create new executor that relies on [`tokio::spawn`] to execute futures.
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::rt::tokio_executor::TokioExecutor;
+    use hyper::rt::Executor;
+    use tokio::sync::oneshot;
+
+    #[cfg(not(miri))]
+    #[tokio::test]
+    async fn simple_execute() -> Result<(), Box<dyn std::error::Error>> {
+        let (tx, rx) = oneshot::channel();
+        let executor = TokioExecutor::new();
+        executor.execute(async move {
+            tx.send(()).unwrap();
+        });
+        rx.await.map_err(Into::into)
+    }
+}


### PR DESCRIPTION
Hey Sean,
I decided to give https://github.com/hyperium/hyper/issues/2861 a go. I'd like to ramp up the contributions after that.

Not certain what exactly is required, feel free to require additional changes.
I tried to write some basic test, but I don't know of a good way to wait for a spawned task without retaining the handle.

Also, I have a question. Why does the `Executor` trait require a generic parameter, wouldn't it make sense to only require it on `execute` function? I.e.:
```
fn execute<Fut>(&self, fut: Fut)
```

Closes https://github.com/hyperium/hyper/issues/2861