### PR TITLE
fix: add missing feature flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ tower-service = "0.3"
 tower = { version = "0.4", features = ["util"] }
 
 [dev-dependencies]
-tokio = { version = "1", features = ["macros"] }
+tokio = { version = "1", features = ["macros", "test-util"] }
 
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dev-dependencies]
 pnet_datalink = "0.27.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,10 @@ tokio = { version = "1", features = ["macros"] }
 pnet_datalink = "0.27.2"
 
 [features]
+runtime = []
+tcp = []
+http1 = []
+http2 = []
 
 # internal features used in CI
 __internal_happy_eyeballs_tests = []

--- a/src/client/connect/http.rs
+++ b/src/client/connect/http.rs
@@ -549,10 +549,10 @@ fn bind_local_address(
 ) -> io::Result<()> {
     match (*dst_addr, local_addr_ipv4, local_addr_ipv6) {
         (SocketAddr::V4(_), Some(addr), _) => {
-            socket.bind(&SocketAddr::new(addr.clone().into(), 0).into())?;
+            socket.bind(&SocketAddr::new((*addr).into(), 0).into())?;
         }
         (SocketAddr::V6(_), _, Some(addr)) => {
-            socket.bind(&SocketAddr::new(addr.clone().into(), 0).into())?;
+            socket.bind(&SocketAddr::new((*addr).into(), 0).into())?;
         }
         _ => {
             if cfg!(windows) {

--- a/src/client/connect/mod.rs
+++ b/src/client/connect/mod.rs
@@ -169,7 +169,7 @@ impl Connected {
     #[cfg(feature = "http2")]
     pub(super) fn clone(&self) -> Connected {
         Connected {
-            alpn: self.alpn.clone(),
+            alpn: self.alpn,
             is_proxied: self.is_proxied,
             extra: self.extra.clone(),
         }

--- a/src/client/pool.rs
+++ b/src/client/pool.rs
@@ -935,7 +935,6 @@ mod tests {
     #[cfg(feature = "runtime")]
     #[tokio::test]
     async fn test_pool_timer_removes_expired() {
-        let _ = pretty_env_logger::try_init();
         tokio::time::pause();
 
         let pool = Pool::new(

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -11,3 +11,6 @@ macro_rules! ready {
 
 pub(crate) use ready;
 pub(crate) mod exec;
+pub(crate) mod never;
+
+pub(crate) use never::Never;

--- a/src/common/never.rs
+++ b/src/common/never.rs
@@ -1,0 +1,21 @@
+//! An uninhabitable type meaning it can never happen.
+//!
+//! To be replaced with `!` once it is stable.
+
+use std::error::Error;
+use std::fmt;
+
+#[derive(Debug)]
+pub(crate) enum Never {}
+
+impl fmt::Display for Never {
+    fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {}
+    }
+}
+
+impl Error for Never {
+    fn description(&self) -> &str {
+        match *self {}
+    }
+}


### PR DESCRIPTION
Closes https://github.com/hyperium/hyper-util/issues/7.

This PR:
* add missing feature flags that were referenced in code, but not in `Cargo.toml`: `runtime`, `tcp`, `http1`, `http2`
* copies `Never` struct from `hyper` and uses it in `client` module to make it compile when features are enabled
* fixes 3 Clippy warnings about preferring `Copy` to `Clone`

There is one test still failing: `client::connect::http::tests::client_happy_eyeballs`. It's a bit over my head, so I didn't attempt to fix it.