### PR TITLE
feat(client): `HttpConnector::tcp_keepalive_interval` and `HttpConnec…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,10 @@ hyper = "0.14.19"
 futures-channel = "0.3"
 futures-util = { version = "0.3", default-features = false }
 http = "0.2"
+
+# Necessary to overcome msrv check of rust 1.49, as 1.15.0 failed
+once_cell = "=1.14"
+
 pin-project-lite = "0.2.4"
 socket2 = "0.4"
 tracing = { version = "0.1", default-features = false, features = ["std"] }


### PR DESCRIPTION
…tor::tcp_keepalive_retries` (#2991)

    If the platform supports setting the options, otherwise it's a noop.

Port from https://github.com/hyperium/hyper/pull/2991