### PR TITLE
Only export `Never` with associated features

### DIFF
--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -13,4 +13,5 @@ pub(crate) use ready;
 pub(crate) mod exec;
 pub(crate) mod never;
 
+#[cfg(feature = "runtime")]
 pub(crate) use never::Never;


### PR DESCRIPTION
This avoids linter errors when not using the runtime feature