### PR TITLE
pool: make relevant items `pub`

### DIFF
--- a/src/client/client.rs
+++ b/src/client/client.rs
@@ -1,7 +1,7 @@
 /// A marker to identify what version a pooled connection is.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[allow(dead_code)]
-pub(super) enum Ver {
+pub enum Ver {
     Auto,
     Http2,
 }

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -10,7 +10,7 @@ macro_rules! ready {
 }
 
 pub(crate) use ready;
-pub(crate) mod exec;
+pub mod exec;
 pub(crate) mod never;
 
 #[cfg(feature = "runtime")]


### PR DESCRIPTION
Currently `pool` is not pub, and nothing `pub` uses it, so it isn't accessible. This exposes them for use.

Discussed here: https://discordapp.com/channels/500028886025895936/670880858630258689/1053021031805227109