### PR TITLE
pool: introduce generic Key parameter

### DIFF
--- a/src/client/pool.rs
+++ b/src/client/pool.rs
@@ -43,7 +43,20 @@ pub(super) trait Poolable: Unpin + Send + Sized + 'static {
     fn can_share(&self) -> bool;
 }
 
-pub trait Key: Eq + Hash + Clone + Debug + Unpin {}
+pub trait Key: Eq + Hash + Clone + Debug + Unpin + Send + 'static {}
+
+impl<T> Key for T where T: Eq + Hash + Clone + Debug + Unpin + Send + 'static {}
+
+type OldKey = (http::uri::Scheme, http::uri::Authority);
+
+fn assert() {
+    let x: OldKey = (http::uri::Scheme::HTTP, "x".parse().expect("host key"));
+    test(x);
+}
+fn test<T: Key>(a: T) {
+}
+
+// impl Key for OldKey {}
 
 /// When checking out a pooled connection, it might be that the connection
 /// only supports a single reservation, or it might be usable for many.
@@ -809,8 +822,6 @@ mod tests {
 
     #[derive(Clone, Debug, PartialEq, Eq, Hash)]
     struct KeyImpl (http::uri::Scheme, http::uri::Authority);
-
-    impl Key for KeyImpl {}
 
     type KeyTuple = (http::uri::Scheme, http::uri::Authority);
 

--- a/src/client/pool.rs
+++ b/src/client/pool.rs
@@ -47,17 +47,6 @@ pub trait Key: Eq + Hash + Clone + Debug + Unpin + Send + 'static {}
 
 impl<T> Key for T where T: Eq + Hash + Clone + Debug + Unpin + Send + 'static {}
 
-type OldKey = (http::uri::Scheme, http::uri::Authority);
-
-fn assert() {
-    let x: OldKey = (http::uri::Scheme::HTTP, "x".parse().expect("host key"));
-    test(x);
-}
-fn test<T: Key>(a: T) {
-}
-
-// impl Key for OldKey {}
-
 /// When checking out a pooled connection, it might be that the connection
 /// only supports a single reservation, or it might be usable for many.
 ///
@@ -810,18 +799,18 @@ impl<T> WeakOpt<T> {
 
 #[cfg(all(test, not(miri)))]
 mod tests {
+    use std::fmt::Debug;
     use std::future::Future;
+    use std::hash::Hash;
     use std::pin::Pin;
     use std::task::{self, Poll};
     use std::time::Duration;
-    use std::fmt::{self, Debug};
-    use std::hash::Hash;
 
-    use super::{Connecting, Pool, Poolable, Reservation, WeakOpt, Key};
+    use super::{Connecting, Key, Pool, Poolable, Reservation, WeakOpt};
     use crate::common::exec::Exec;
 
     #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-    struct KeyImpl (http::uri::Scheme, http::uri::Authority);
+    struct KeyImpl(http::uri::Scheme, http::uri::Authority);
 
     type KeyTuple = (http::uri::Scheme, http::uri::Authority);
 
@@ -852,7 +841,6 @@ mod tests {
 
     fn host_key(s: &str) -> KeyImpl {
         KeyImpl(http::uri::Scheme::HTTP, s.parse().expect("host key"))
-        
     }
 
     fn pool_no_timer<T, K: Key>() -> Pool<T, K> {


### PR DESCRIPTION
This PR makes pooling generic over the Key type, so the caller can decide how they wish to pool the client connections.

This PR builds on the work done by @EItanya (my colleague who is going OOO for a bit, so I took over) in https://github.com/hyperium/hyper-util/pull/12.

Since that PR, support for the `runtime` feature was introduced, and a blanket impl was added for Key (see https://github.com/hyperium/hyper-util/pull/12#discussion_r1049919896).

With this and https://github.com/hyperium/hyper-util/pull/15 pulled locally, I was able to get a full custom pooling implementation in our project. edit: actually only can pool with `Reservation::Unique` at this point since SendRequest isn't `Clone` and `into_http2()` is private. But those can be addressed I think.