### PR TITLE
Unlock once_cell version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ futures-channel = "0.3"
 futures-util = { version = "0.3", default-features = false }
 http = "0.2"
 
-once_cell = "1.17"
+once_cell = "1.14"
 
 pin-project-lite = "0.2.4"
 socket2 = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,7 @@ futures-channel = "0.3"
 futures-util = { version = "0.3", default-features = false }
 http = "0.2"
 
-# Necessary to overcome msrv check of rust 1.49, as 1.15.0 failed
-once_cell = "=1.14"
+once_cell = "1.17"
 
 pin-project-lite = "0.2.4"
 socket2 = "0.4"


### PR DESCRIPTION
In CI MSRV is set to 1.56. It seems lock once_cell to 1.14 is not necessary，and this lock cause conflict with many other crates.