### PR TITLE
Expose `exec` crate publicly

### DIFF
--- a/src/common/exec.rs
+++ b/src/common/exec.rs
@@ -6,7 +6,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
-pub(crate) type BoxSendFuture = Pin<Box<dyn Future<Output = ()> + Send>>;
+pub type BoxSendFuture = Pin<Box<dyn Future<Output = ()> + Send>>;
 
 // Either the user provides an executor for background tasks, or we use
 // `tokio::spawn`.
@@ -19,7 +19,7 @@ pub enum Exec {
 // ===== impl Exec =====
 
 impl Exec {
-    pub(crate) fn new<E>(inner: E) -> Self
+    pub fn new<E>(inner: E) -> Self
     where
         E: Executor<BoxSendFuture> + Send + Sync + 'static,
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,3 +6,5 @@
 pub mod client;
 mod common;
 pub mod rt;
+
+pub use common::exec::*;


### PR DESCRIPTION
Currently, the `Pool` crate is public. However, it requires an `Exec` which I think is not possible to instantiate currently. This PR exposes `exec` so the pool can be used directly without the higher level Client.

This was public prior to https://github.com/hyperium/hyper/pull/3155/files