### PR TITLE
client: add timer() option

### DIFF
--- a/src/client/legacy.rs
+++ b/src/client/legacy.rs
@@ -14,6 +14,7 @@ use std::time::Duration;
 use futures_util::future::{self, Either, FutureExt, TryFutureExt};
 use http::uri::Scheme;
 use hyper::header::{HeaderValue, HOST};
+use hyper::rt::Timer;
 use hyper::{body::Body, Method, Request, Response, Uri, Version};
 use tracing::{debug, trace, warn};
 
@@ -1346,6 +1347,22 @@ impl Builder {
     #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
     pub fn http2_max_concurrent_reset_streams(&mut self, max: usize) -> &mut Self {
         self.h2_builder.max_concurrent_reset_streams(max);
+        self
+    }
+
+    /// Provide a timer to execute background HTTP2 tasks
+    ///
+    /// See the documentation of [`h2::client::Builder::timer`] for more
+    /// details.
+    ///
+    /// [`h2::client::Builder::timer`]: https://docs.rs/h2/client/struct.Builder.html#method.timer
+    pub fn timer<M>(&mut self, timer: M) -> &mut Self
+    where
+        M: Timer + Send + Sync + 'static,
+    {
+        #[cfg(feature = "http2")]
+        self.h2_builder.timer(timer);
+        // TODO(https://github.com/hyperium/hyper/issues/3167) set for pool as well
         self
     }
 

--- a/src/client/legacy.rs
+++ b/src/client/legacy.rs
@@ -1350,7 +1350,7 @@ impl Builder {
         self
     }
 
-    /// Provide a timer to execute background HTTP2 tasks
+    /// Provide a timer to be used for timeouts and intervals.
     ///
     /// See the documentation of [`h2::client::Builder::timer`] for more
     /// details.


### PR DESCRIPTION
Currently, a timer must be provided to use http2. However, this has no option to actually configure this. This PR introduces a new function to set the timer. With this, I am able to successfully make HTTP2 calls with the Client (as long as there is no error - currently we hit a todo!() on errors)