### PR TITLE
chore(ci): update ci config

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,11 +26,9 @@ jobs:
     name: Check Style
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
 
@@ -54,8 +52,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
       - name: Install Rust (${{ matrix.rust }})
         uses: dtolnay/rust-toolchain@master
@@ -78,8 +75,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
       - name: Install Rust (${{ matrix.rust }})
         uses: dtolnay/rust-toolchain@master
@@ -94,11 +90,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@nightly
         with:
           components: miri
 
@@ -113,27 +107,21 @@ jobs:
     needs: [style]
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@nightly
 
       - uses: taiki-e/install-action@cargo-hack
 
-      - name: check --feature-powerset
-        run: cargo hack check --feature-powerset --depth 2 -Z avoid-dev-deps
+      - run: cargo hack check --feature-powerset --depth 2 -Z avoid-dev-deps
 
   doc:
     name: Build docs
     needs: [style, test]
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@nightly
 
-      - name: cargo doc
-        run: cargo rustdoc -- --cfg docsrs -D broken-intra-doc-links
+      - run: cargo rustdoc -- --cfg docsrs -D broken-intra-doc-links

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,21 +27,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
           components: rustfmt
 
-      - name: cargo fmt --check
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - run: cargo fmt --all --check
 
   test:
     name: Test ${{ matrix.rust }} on ${{ matrix.os }}
@@ -62,19 +55,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Install Rust (${{ matrix.rust }})
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
-          override: true
 
-      - name: Test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
+      - run: cargo test
 
   msrv:
     name: Check MSRV (${{ matrix.rust }})
@@ -91,19 +79,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Install Rust (${{ matrix.rust }})
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
-          override: true
 
-      - name: Check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
+      - run: cargo check
 
   miri:
     name: Test with Miri
@@ -112,19 +95,18 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@nightly
         with:
-          profile: minimal
-          toolchain: nightly
           components: miri
-          override: true
 
       - name: Test
-        # Can't enable tcp feature since Miri does not support the tokio runtime
-        run: MIRIFLAGS="-Zmiri-disable-isolation" cargo miri test
+        env:
+          # Can't enable tcp feature since Miri does not support the tokio runtime
+          MIRIFLAGS: "-Zmiri-disable-isolation"
+        run: cargo miri test
 
   features:
     name: features
@@ -132,17 +114,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
+        uses: dtolnay/rust-toolchain@nightly
 
-      - name: Install cargo-hack
-        run: cargo install cargo-hack
+      - uses: taiki-e/install-action@cargo-hack
 
       - name: check --feature-powerset
         run: cargo hack check --feature-powerset --depth 2 -Z avoid-dev-deps
@@ -153,17 +130,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
+        uses: dtolnay/rust-toolchain@nightly
 
       - name: cargo doc
-        uses: actions-rs/cargo@v1
-        with:
-          command: rustdoc
-          args: -- --cfg docsrs -D broken-intra-doc-links
+        run: cargo rustdoc -- --cfg docsrs -D broken-intra-doc-links


### PR DESCRIPTION
Updates ci configs.

- Updates to use actions/checkout@v3 from v1.
- Replaces actions-rs/toolchain with dtolnay/rust-toolchain as it is unmaintained.
- Replaces actions-rs/cargo with run as it is unmaintained.
- Replaces `cargo install` with taiki-e/install-action to install cargo-hack to avoid compiling it every ci.
- Removes redundant step names.