### PR TITLE
chore: fix warnings for unused macro

### DIFF
--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,15 +1,5 @@
 #![allow(missing_docs)]
 
-macro_rules! ready {
-    ($e:expr) => {
-        match $e {
-            std::task::Poll::Ready(v) => v,
-            std::task::Poll::Pending => return std::task::Poll::Pending,
-        }
-    };
-}
-
-pub(crate) use ready;
 pub mod exec;
 #[cfg(feature = "client")]
 mod lazy;


### PR DESCRIPTION
I believe this is safe; the macro should not be exported without `macro_export`

Without this, we see warnings:

```
warning: unused macro definition: `ready`
 --> src/common/mod.rs:3:14
  |
3 | macro_rules! ready {
  |              ^^^^^
  |
  = note: `#[warn(unused_macros)]` on by default

warning: unused import: `ready`
  --> src/common/mod.rs:12:16
   |
12 | pub(crate) use ready;
   |                ^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: `hyper-util` (lib) generated 2 warnings (run `cargo fix --lib -p hyper-util` to apply 1 suggestion)
warning: `hyper-util` (lib test) generated 2 warnings (2 duplicates)
```