### PR TITLE
Update socket2 dependency in Cargo.toml.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ tokio = { version = "1", features = ["macros", "test-util"] }
 pnet_datalink = "0.27.2"
 
 [features]
-default = ["full"]
+default = []
 
 # Shorthand to enable everything
 full = ["client", "server", "http1", "http2", "tcp", "runtime"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ http = "0.2"
 once_cell = "1.14"
 
 pin-project-lite = "0.2.4"
-socket2 = "0.4"
+socket2 = "0.5.3"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 tokio = { version = "1", features = ["net", "rt", "time"] }
 tower-service = "0.3"
@@ -38,7 +38,7 @@ tokio = { version = "1", features = ["macros", "test-util"] }
 pnet_datalink = "0.27.2"
 
 [features]
-default = []
+default = ["full"]
 
 # Shorthand to enable everything
 full = ["client", "server", "http1", "http2", "tcp", "runtime"]


### PR DESCRIPTION
The current tip of main does not compile on Linux due to an invalid version of socket2. 