### PR TITLE
chore: use futures_util::ready

### DIFF
--- a/src/client/legacy/pool.rs
+++ b/src/client/legacy/pool.rs
@@ -15,9 +15,10 @@ use std::task::{self, Poll};
 use std::time::{Duration, Instant};
 
 use futures_channel::oneshot;
+use futures_util::ready;
 use tracing::{debug, trace};
 
-use crate::common::{exec, exec::Exec, ready};
+use crate::common::exec::{self, Exec};
 
 // FIXME: allow() required due to `impl Trait` leaking types to this lint
 #[allow(missing_debug_implementations)]

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,15 +1,5 @@
 #![allow(missing_docs)]
 
-macro_rules! ready {
-    ($e:expr) => {
-        match $e {
-            std::task::Poll::Ready(v) => v,
-            std::task::Poll::Pending => return std::task::Poll::Pending,
-        }
-    };
-}
-
-pub(crate) use ready;
 pub(crate) mod exec;
 #[cfg(feature = "client")]
 mod lazy;


### PR DESCRIPTION
`hyper-util` could use `futures_util::ready`.