### PR TITLE
fix: replace std::task::ready with futures_util::ready

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -87,7 +87,7 @@ jobs:
           cargo update
           cargo update -p log --precise 0.4.18
 
-      - run: cargo check
+      - run: cargo check --features full
 
   miri:
     name: Test with Miri

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ pnet_datalink = "0.27.2"
 default = []
 
 # Shorthand to enable everything
-full = ["client", "server", "http1", "http2", "tcp", "runtime"]
+full = ["client", "server", "http1", "http2", "tcp", "auto", "runtime"]
 
 client = ["hyper/client"]
 server = ["hyper/server"]

--- a/src/server/conn/auto.rs
+++ b/src/server/conn/auto.rs
@@ -1,10 +1,11 @@
 //! Http1 or Http2 connection.
 
+use futures_util::ready;
 use std::future::Future;
 use std::io::{Error as IoError, ErrorKind, Result as IoResult};
 use std::marker::PhantomPinned;
 use std::pin::Pin;
-use std::task::{ready, Context, Poll};
+use std::task::{Context, Poll};
 use std::{error::Error as StdError, marker::Unpin, time::Duration};
 
 use bytes::Bytes;


### PR DESCRIPTION
Replaces `std::task::ready` with `futures_util::ready`, as the former requires Rust 1.64, which is larger than `hyper-util`'s MSRV 1.63.