### PR TITLE
refactor(common): replace Never with Infallible

### DIFF
--- a/src/client/pool.rs
+++ b/src/client/pool.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::convert::Infallible;
 use std::error::Error as StdError;
 use std::fmt::{self, Debug};
 use std::future::Future;
@@ -97,7 +98,7 @@ struct PoolInner<T, K: Eq + Hash> {
     // A oneshot channel is used to allow the interval to be notified when
     // the Pool completely drops. That way, the interval can cancel immediately.
     #[cfg(feature = "runtime")]
-    idle_interval_ref: Option<oneshot::Sender<crate::common::Never>>,
+    idle_interval_ref: Option<oneshot::Sender<Infallible>>,
     #[cfg(feature = "runtime")]
     exec: Exec,
     timeout: Option<Duration>,
@@ -771,7 +772,7 @@ pin_project_lite::pin_project! {
         // Pool is fully dropped, and shutdown. This channel is never sent on,
         // but Err(Canceled) will be received when the Pool is dropped.
         #[pin]
-        pool_drop_notifier: oneshot::Receiver<crate::common::Never>,
+        pool_drop_notifier: oneshot::Receiver<Infallible>,
     }
 }
 

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -13,7 +13,6 @@ pub(crate) use ready;
 pub mod exec;
 #[cfg(feature = "client")]
 mod lazy;
-pub(crate) mod never;
 pub(crate) mod rewind;
 #[cfg(feature = "client")]
 mod sync;
@@ -23,7 +22,5 @@ pub(crate) use exec::Exec;
 
 #[cfg(feature = "client")]
 pub(crate) use lazy::{lazy, Started as Lazy};
-#[cfg(feature = "runtime")]
-pub(crate) use never::Never;
 #[cfg(feature = "client")]
 pub(crate) use sync::SyncWrapper;


### PR DESCRIPTION
Replaces `Never` with `std::convert::Infallible` as with https://github.com/hyperium/hyper/pull/3335.