### PR TITLE
Drop Send requirements on the future returned by the service

### DIFF
--- a/src/server/conn/auto.rs
+++ b/src/server/conn/auto.rs
@@ -69,7 +69,7 @@ impl<E> Builder<E> {
     pub async fn serve_connection<I, S, B>(&self, io: I, service: S) -> Result<()>
     where
         S: Service<Request<Incoming>, Response = Response<B>> + Send,
-        S::Future: Send + 'static,
+        S::Future: 'static,
         S::Error: Into<Box<dyn StdError + Send + Sync>>,
         B: Body + Send + 'static,
         B::Data: Send,

--- a/src/server/conn/auto.rs
+++ b/src/server/conn/auto.rs
@@ -93,7 +93,7 @@ impl<E> Builder<E> {
     pub async fn serve_connection_with_upgrades<I, S, B>(&self, io: I, service: S) -> Result<()>
     where
         S: Service<Request<Incoming>, Response = Response<B>> + Send,
-        S::Future: Send + 'static,
+        S::Future: 'static,
         S::Error: Into<Box<dyn StdError + Send + Sync>>,
         B: Body + Send + 'static,
         B::Data: Send,


### PR DESCRIPTION
The current bounds appear to be too strict when it comes to `Send`ness, preventing the usage of `auto` in combination with an implementation of `Executor` that's designed to spawn `!Send` futures.