### PR TITLE
chore(ci): use cargo-hack --no-dev-deps option to check without dev-dependencies

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -114,11 +114,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@stable
 
       - uses: taiki-e/install-action@cargo-hack
 
-      - run: cargo hack check --feature-powerset --depth 2 -Z avoid-dev-deps
+      - run: cargo hack --no-dev-deps check --feature-powerset --depth 2
 
   doc:
     name: Build docs


### PR DESCRIPTION
Uses `cargo-hack`'s `--no-dev-deps` option to check without dev-dependencies as with https://github.com/hyperium/hyper/pull/3342.