### PR TITLE
chore(dependencies): remove once_cell crate version config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,6 @@ futures-util = { version = "0.3", default-features = false }
 http = "0.2"
 http-body = "1.0.0-rc.2"
 bytes = "1"
-
-once_cell = "1.14"
-
 pin-project-lite = "0.2.4"
 socket2 = "0.5"
 tracing = { version = "0.1", default-features = false, features = ["std"] }


### PR DESCRIPTION
The `once_cell` crate version config seems not to be needed now.