### PR TITLE
feat(service): add adapter for tower services

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,3 +60,7 @@ __internal_happy_eyeballs_tests = []
 [[example]]
 name = "client"
 required-features = ["client", "http1", "tcp", "runtime"]
+
+[[example]]
+name = "tower_server"
+required-features = ["server", "http1", "tcp", "runtime"]

--- a/examples/tower_server.rs
+++ b/examples/tower_server.rs
@@ -1,0 +1,27 @@
+use bytes::Bytes;
+use http::{Request, Response};
+use http_body_util::Full;
+use hyper::body::Incoming;
+use hyper_util::{rt::TokioExecutor, server::conn::auto::Builder};
+use tokio::net::TcpListener;
+use tower::BoxError;
+
+async fn handle(_request: Request<Incoming>) -> Result<Response<Full<Bytes>>, BoxError> {
+    Ok(Response::new(Full::from("Hello, World!")))
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let tower_service = tower::service_fn(handle);
+
+    let listener = TcpListener::bind("0.0.0.0:3000").await.unwrap();
+    loop {
+        let (tcp_stream, _remote_addr) = listener.accept().await.unwrap();
+        if let Err(err) = Builder::new(TokioExecutor::new())
+            .serve_connection_with_upgrades_tower(tcp_stream, tower_service)
+            .await
+        {
+            eprintln!("failed to serve connection: {err:#}");
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,5 +8,10 @@ pub mod client;
 mod common;
 pub mod rt;
 pub mod server;
+#[cfg(all(
+    any(feature = "http1", feature = "http2"),
+    any(feature = "server", feature = "client")
+))]
+pub mod service;
 
 mod error;

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,0 +1,70 @@
+//! Service utilities.
+
+use pin_project_lite::pin_project;
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use tower::{util::Oneshot, ServiceExt};
+
+/// A tower service converted into a hyper service.
+#[cfg(all(
+    any(feature = "http1", feature = "http2"),
+    any(feature = "server", feature = "client")
+))]
+#[derive(Debug, Copy, Clone)]
+pub struct TowerToHyperService<S> {
+    service: S,
+}
+
+impl<S> TowerToHyperService<S> {
+    /// Create a new `TowerToHyperService` from a tower service.
+    pub fn new(tower_service: S) -> Self {
+        Self {
+            service: tower_service,
+        }
+    }
+}
+
+impl<S, R> hyper::service::Service<R> for TowerToHyperService<S>
+where
+    S: tower_service::Service<R> + Clone,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = TowerToHyperServiceFuture<S, R>;
+
+    fn call(&self, req: R) -> Self::Future {
+        TowerToHyperServiceFuture {
+            future: self.service.clone().oneshot(req),
+        }
+    }
+}
+
+pin_project! {
+    /// Response future for [`TowerToHyperService`].
+    #[cfg(all(
+        any(feature = "http1", feature = "http2"),
+        any(feature = "server", feature = "client")
+    ))]
+    pub struct TowerToHyperServiceFuture<S, R>
+    where
+        S: tower_service::Service<R>,
+    {
+        #[pin]
+        future: Oneshot<S, R>,
+    }
+}
+
+impl<S, R> Future for TowerToHyperServiceFuture<S, R>
+where
+    S: tower_service::Service<R>,
+{
+    type Output = Result<S::Response, S::Error>;
+
+    #[inline]
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.project().future.poll(cx)
+    }
+}


### PR DESCRIPTION
This adds

- `TowerToHyperService` which converts a tower service into a hyper service.
- `Builder::serve_connection_tower` and `Builder::serve_connection_with_upgrades_tower` for serving a tower service directly. The adapter will be applied internally.
- An example showing how to use it since there was previously only a client example.