### PR TITLE
pool: use `Executor` trait instead of concrete type

### DIFF
--- a/src/client/legacy.rs
+++ b/src/client/legacy.rs
@@ -1413,15 +1413,16 @@ impl Builder {
         B: Body + Send,
         B::Data: Send,
     {
+        let exec = self.exec.clone();
         Client {
             config: self.client_config,
-            exec: self.exec.clone(),
+            exec: exec.clone(),
             #[cfg(feature = "http1")]
             h1_builder: self.h1_builder.clone(),
             #[cfg(feature = "http2")]
             h2_builder: self.h2_builder.clone(),
             connector,
-            pool: pool::Pool::new(self.pool_config, &self.exec),
+            pool: pool::Pool::new(self.pool_config, exec),
         }
     }
 }


### PR DESCRIPTION
Alternative to https://github.com/hyperium/hyper-util/pull/24.

Currently, `Pool` cannot be used at all. It requires a concrete `Exec`, and that is private. The #24 PR simply made `Exec` public. However, there is already other things in this crate that require an `Exec` (`legacy::Client`).

This adapts `Pool` to follow the same pattern as used for `Client`, taking in a trait.

This change is NOT a breaking change, as `Pool` cannot be used at all currently, so no one could be broken.