### PR TITLE
Re-expose connect::Error after #49

### DIFF
--- a/src/client/legacy/mod.rs
+++ b/src/client/legacy/mod.rs
@@ -2,5 +2,7 @@
 mod client;
 #[cfg(any(feature = "http1", feature = "http2"))]
 pub use client::Client;
+#[cfg(any(feature = "http1", feature = "http2"))]
+pub use client::Error;
 
 pub mod connect;


### PR DESCRIPTION
Since #49, we cannot refer to the Error response from the client. This exposes it again