### PR TITLE
Feature flags: `server-auto` should imply `server`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ client = ["hyper/client"]
 client-legacy = ["client"]
 
 server = ["hyper/server"]
-server-auto = ["hyper/server", "http1", "http2"]
+server-auto = ["server", "http1", "http2"]
 
 http1 = ["hyper/http1"]
 http2 = ["hyper/http2"]


### PR DESCRIPTION
As it currently stands, enabling `server-auto` doesn't actually give you access to any new item _unless_ you also enable the `server` feature.
Considering how the code is structured, I think that the `server-auto` feature flag should imply the `server` feature flag.