### PR TITLE
Enable all feature flags when generating docs for docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ keywords = ["http", "hyper", "hyperium"]
 categories = ["network-programming", "web-programming::http-client", "web-programming::http-server"]
 edition = "2018"
 
+[package.metadata.docs.rs]
+features = ["full"]
+
 [dependencies]
 hyper = "1.0.0"
 futures-channel = "0.3"


### PR DESCRIPTION
The documentation on docs.rs is empty at the moment, which is not very useful.
This PR enables the `full` feature flag when building docs for docs.rs to make sure all items are documented.