### PR TITLE
Add socket2 feature "all"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ http = "1.0"
 http-body = "1.0.0"
 bytes = "1"
 pin-project-lite = "0.2.4"
-socket2 = { version = "0.5", optional = true }
+socket2 = { version = "0.5", optional = true, features = ["all"] }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 tokio = { version = "1", optional = true, features = ["net", "rt", "time"] }
 tower-service = "0.3"


### PR DESCRIPTION
Without this, I see
```rust
error[E0599]: no method named `bind_device` found for struct `Socket` in the current scope
   --> /home/jayvdb/.cargo/registry/src/index.crates.io-6f17d22bba15001f/hyper-util-0.1.1/src/client/legacy/connect/http.rs:704:14
    |
703 | /         socket
704 | |             .bind_device(Some(interface.as_bytes()))
    | |             -^^^^^^^^^^^ method not found in `Socket`
    | |_____________|
    | 

error[E0599]: no method named `with_retries` found for struct `TcpKeepalive` in the current scope
   --> /home/jayvdb/.cargo/registry/src/index.crates.io-6f17d22bba15001f/hyper-util-0.1.1/src/client/legacy/connect/http.rs:130:12
    |
130 |         ka.with_retries(retries)
    |            ^^^^^^^^^^^^ help: there is a method with a similar name: `with_time`

For more information about this error, try `rustc --explain E0599`.
error: could not compile `hyper-util` (lib) due to 2 previous errors
```