### PR TITLE
Fix `cargo minimal-versions check`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 hyper = "1.0.0"
 futures-channel = "0.3"
-futures-util = { version = "0.3", default-features = false }
+futures-util = { version = "0.3.16", default-features = false }
 http = "1.0"
 http-body = "1.0.0"
 bytes = "1"
@@ -28,7 +28,7 @@ socket2 = { version = "0.5", optional = true, features = ["all"] }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 tokio = { version = "1", optional = true, features = ["net", "rt", "time"] }
 tower-service = "0.3"
-tower = { version = "0.4", features = ["make", "util"] }
+tower = { version = "0.4.1", features = ["make", "util"] }
 
 [dev-dependencies]
 hyper = { version = "1.0.0", features = ["full"] }


### PR DESCRIPTION
In a `Cargo.toml`, the dependency versions mean that those versions are the minimum versions required for the project to build.
Sadly, the minimum versions that are given right now will cause compiler errors.

This can be checked through the tool [`cargo-minimal-versions`](https://crates.io/crates/cargo-minimal-versions).

This change modifies the minimal versions so that `cargo minimal-versions check` now succeeds.