### PR TITLE
feat: add `TowerToHyperService`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,5 +12,10 @@ mod common;
 pub mod rt;
 #[cfg(feature = "server")]
 pub mod server;
+#[cfg(all(
+    any(feature = "http1", feature = "http2"),
+    any(feature = "server", feature = "client")
+))]
+pub mod service;
 
 mod error;

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,0 +1,70 @@
+//! Service utilities.
+
+use pin_project_lite::pin_project;
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use tower::{util::Oneshot, ServiceExt};
+
+/// A tower service converted into a hyper service.
+#[cfg(all(
+    any(feature = "http1", feature = "http2"),
+    any(feature = "server", feature = "client")
+))]
+#[derive(Debug, Copy, Clone)]
+pub struct TowerToHyperService<S> {
+    service: S,
+}
+
+impl<S> TowerToHyperService<S> {
+    /// Create a new `TowerToHyperService` from a tower service.
+    pub fn new(tower_service: S) -> Self {
+        Self {
+            service: tower_service,
+        }
+    }
+}
+
+impl<S, R> hyper::service::Service<R> for TowerToHyperService<S>
+where
+    S: tower_service::Service<R> + Clone,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = TowerToHyperServiceFuture<S, R>;
+
+    fn call(&self, req: R) -> Self::Future {
+        TowerToHyperServiceFuture {
+            future: self.service.clone().oneshot(req),
+        }
+    }
+}
+
+pin_project! {
+    /// Response future for [`TowerToHyperService`].
+    #[cfg(all(
+        any(feature = "http1", feature = "http2"),
+        any(feature = "server", feature = "client")
+    ))]
+    pub struct TowerToHyperServiceFuture<S, R>
+    where
+        S: tower_service::Service<R>,
+    {
+        #[pin]
+        future: Oneshot<S, R>,
+    }
+}
+
+impl<S, R> Future for TowerToHyperServiceFuture<S, R>
+where
+    S: tower_service::Service<R>,
+{
+    type Output = Result<S::Response, S::Error>;
+
+    #[inline]
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.project().future.poll(cx)
+    }
+}


### PR DESCRIPTION
Extracted from https://github.com/hyperium/hyper-util/pull/46. This adds `TowerToHyperService` which converts a tower service into a hyper service. Among other things, this is useful for running axum with hyper.