### PR TITLE
Support graceful shutdown on "auto conn"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,3 +71,6 @@ __internal_happy_eyeballs_tests = []
 [[example]]
 name = "client"
 required-features = ["client-legacy", "http1", "tokio"]
+
+[patch.crates-io]
+hyper = { git = "https://github.com/hyperium/hyper", rev = "cf68ea902749e" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ features = ["full"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-hyper = "1.0.0"
+hyper = "1.1.0"
 futures-channel = "0.3"
 futures-util = { version = "0.3.16", default-features = false }
 http = "1.0"
@@ -31,7 +31,7 @@ tower-service = "0.3"
 tower = { version = "0.4.1", features = ["make", "util"] }
 
 [dev-dependencies]
-hyper = { version = "1.0.0", features = ["full"] }
+hyper = { version = "1.1.0", features = ["full"] }
 bytes = "1"
 http-body-util = "0.1.0"
 tokio = { version = "1", features = ["macros", "test-util"] }
@@ -71,6 +71,3 @@ __internal_happy_eyeballs_tests = []
 [[example]]
 name = "client"
 required-features = ["client-legacy", "http1", "tokio"]
-
-[patch.crates-io]
-hyper = { git = "https://github.com/hyperium/hyper", rev = "cf68ea902749e" }

--- a/src/server/conn/auto.rs
+++ b/src/server/conn/auto.rs
@@ -89,7 +89,11 @@ impl<E> Builder<E> {
     /// Bind a connection together with a [`Service`], with the ability to
     /// handle HTTP upgrades. This requires that the IO object implements
     /// `Send`.
-    pub fn serve_connection_with_upgrades<I, S, B>(&self, io: I, service: S) -> UpgradeableConnection<'_, I, S, E>
+    pub fn serve_connection_with_upgrades<I, S, B>(
+        &self,
+        io: I,
+        service: S,
+    ) -> UpgradeableConnection<'_, I, S, E>
     where
         S: Service<Request<Incoming>, Response = Response<B>>,
         S::Future: 'static,


### PR DESCRIPTION
This PR aims to unblock axum adding some kind of graceful shutdown convenience API. A somewhat common complaint with axum 0.7 is that graceful shutdown is more complicated than it was with `hyper::Server`.

axum provides a basic [`serve`](https://docs.rs/axum/latest/axum/fn.serve.html) function that needs to support both http1 and http2. Therefore we use hyper-utils "auto conn" but that doesn't support graceful shutdown.

This PR aims to implement a minimal way to unblock that without having write a whole new server type:

- Instead of  [`hyper_util::server::conn::auto::Builder::serve_connection_with_upgrades`](https://docs.rs/hyper-util/latest/hyper_util/server/conn/auto/struct.Builder.html#method.serve_connection) being an `async fn` that returns an opaque future, return something that holds the underlying `Connection` (and implements `Future`)
- That would be some type with an inner enum that either contains an `http1::Connection` or an `http2::Connection`
- A `pub fn graceful_shutdown(self: Pin<&mut Self>)` method that delegates to the inner `Connection`

I have it working for `hyper_util::server::conn::auto::Builder::serve_connection` but I don't think `serve_connection_with_upgrades` is possible since hyper's `UpgradeableConnection` type isn't nameable 😞 This is something I suspect we'll run into as well if we were to add something akin to `hyper::Server` to this crate.

@seanmonstar What do you think about this approach? Do you see hyper exposing `UpgradeableConnection`? It not then do you have any other suggestions?