### PR TITLE
chore(ci): update rustdoc lint name

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -124,4 +124,4 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@nightly
 
-      - run: cargo rustdoc -- --cfg docsrs -D broken-intra-doc-links
+      - run: cargo rustdoc -- --cfg docsrs -D rustdoc::broken-intra-doc-links


### PR DESCRIPTION
Updates the rustdoc lint name.