### PR TITLE
feat: make builder clonable

### DIFF
--- a/src/server/conn/auto.rs
+++ b/src/server/conn/auto.rs
@@ -26,6 +26,7 @@ type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>
 const H2_PREFACE: &[u8] = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
 
 /// Http1 or Http2 connection builder.
+#[derive(Clone, Debug)]
 pub struct Builder<E> {
     http1: http1::Builder,
     http2: http2::Builder<E>,


### PR DESCRIPTION
Being able to create a single builder, which then can be cloned to enable reuse would be ideal. Also implements `Debug` for the builder.