### PR TITLE
feat: Add TokioTimer to rt::tokio module

### DIFF
--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -4,4 +4,4 @@
 pub mod tokio;
 
 #[cfg(feature = "tokio")]
-pub use self::tokio::{TokioExecutor, TokioIo};
+pub use self::tokio::{TokioExecutor, TokioIo, TokioTimer};

--- a/src/rt/tokio.rs
+++ b/src/rt/tokio.rs
@@ -246,7 +246,7 @@ impl Future for TokioSleep {
 impl Sleep for TokioSleep {}
 
 impl TokioSleep {
-    pub fn reset(self: Pin<&mut Self>, deadline: Instant) {
+    fn reset(self: Pin<&mut Self>, deadline: Instant) {
         self.project().inner.as_mut().reset(deadline.into());
     }
 }


### PR DESCRIPTION
In the latest master branch of `hyper` the `hello` server example has been changed to include a `TokioTimer`.

This exists in `hyper`'s `support` module, but does not yet exist in `hyper-util`.

This PR adds that functionality by copying over the implementation from `hyper`.

Similar to `TokioExecutor` in this repo. It can only be created through the `new` constructor. This differs from `hyper`'s `support` module, where both `TokioExecutor` and `TokioTimer` are directly creatable as an empty struct.