### PR TITLE
fix(http): divide by zero error when dividing duration by scalar

### DIFF
--- a/src/client/legacy/connect/http.rs
+++ b/src/client/legacy/connect/http.rs
@@ -606,7 +606,9 @@ struct ConnectingTcpRemote {
 
 impl ConnectingTcpRemote {
     fn new(addrs: dns::SocketAddrs, connect_timeout: Option<Duration>) -> Self {
-        let connect_timeout = connect_timeout.map(|t| t / (addrs.len() as u32));
+        let connect_timeout = connect_timeout
+            .map(|t| t.checked_div(addrs.len() as u32))
+            .flatten();
 
         Self {
             addrs,


### PR DESCRIPTION
from hyper 0.14.x
commit：https://github.com/hyperium/hyper/pull/3355