### PR TITLE
Add back `max_pending_accept_reset_streams`

### DIFF
--- a/src/client/legacy/client.rs
+++ b/src/client/legacy/client.rs
@@ -1238,6 +1238,22 @@ impl Builder {
         self
     }
 
+    /// Configures the maximum number of pending reset streams allowed before a GOAWAY will be sent.
+    ///
+    /// This will default to the default value set by the [`h2` crate](https://crates.io/crates/h2).
+    /// As of v0.4.0, it is 20.
+    ///
+    /// See <https://github.com/hyperium/hyper/issues/2877> for more information.
+    #[cfg(feature = "http2")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
+    pub fn http2_max_pending_accept_reset_streams(
+        &mut self,
+        max: impl Into<Option<usize>>,
+    ) -> &mut Self {
+        self.h2_builder.max_pending_accept_reset_streams = max.into();
+        self
+    }
+
     /// Sets the [`SETTINGS_INITIAL_WINDOW_SIZE`][spec] option for HTTP2
     /// stream-level flow control.
     ///

--- a/src/server/conn/auto.rs
+++ b/src/server/conn/auto.rs
@@ -551,6 +551,17 @@ impl<E> Http2Builder<'_, E> {
         }
     }
 
+    /// Configures the maximum number of pending reset streams allowed before a GOAWAY will be sent.
+    ///
+    /// This will default to the default value set by the [`h2` crate](https://crates.io/crates/h2).
+    /// As of v0.4.0, it is 20.
+    ///
+    /// See <https://github.com/hyperium/hyper/issues/2877> for more information.
+    pub fn max_pending_accept_reset_streams(mut self, max: impl Into<Option<usize>>) -> Self {
+        self.protocol.http2_max_pending_accept_reset_streams(max);
+        self
+    }
+
     /// Sets the [`SETTINGS_INITIAL_WINDOW_SIZE`][spec] option for HTTP2
     /// stream-level flow control.
     ///


### PR DESCRIPTION
Adds back this function which was previously in hyper 0.14.

The original merge into hyper is
[here](https://github.com/hyperium/hyper/pull/3201/files/e8296d1c5bded88a508f1ca1f35791c30803182d)

This follows the original closely, with some minor wording improvements in the outer line docs.

Closes https://github.com/hyperium/hyper/issues/3461.