### PR TITLE
feat: tower should be an optional dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ pin-project-lite = "0.2.4"
 socket2 = { version = "0.5", optional = true, features = ["all"] }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 tokio = { version = "1", optional = true, features = ["net", "rt", "time"] }
-tower-service = "0.3"
-tower = { version = "0.4.1", features = ["make", "util"] }
+tower-service ={ version = "0.3", optional = true }
+tower = { version = "0.4.1", optional = true, features = ["make", "util"] }
 
 [dev-dependencies]
 hyper = { version = "1.0.0", features = ["full"] }
@@ -49,16 +49,18 @@ full = [
     "client-legacy",
     "server",
     "server-auto",
+    "service",
     "http1",
     "http2",
     "tokio",
 ]
 
-client = ["hyper/client"]
+client = ["hyper/client", "dep:tower-service", "dep:tower"]
 client-legacy = ["client"]
 
 server = ["hyper/server"]
 server-auto = ["server", "http1", "http2"]
+service = ["dep:tower"]
 
 http1 = ["hyper/http1"]
 http2 = ["hyper/http2"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,12 +55,13 @@ full = [
     "tokio",
 ]
 
-client = ["hyper/client", "dep:tower-service", "dep:tower"]
+client = ["hyper/client", "dep:tower", "dep:tower-service"]
 client-legacy = ["client"]
 
 server = ["hyper/server"]
 server-auto = ["server", "http1", "http2"]
-service = ["dep:tower"]
+
+service = ["dep:tower", "dep:tower-service"]
 
 http1 = ["hyper/http1"]
 http2 = ["hyper/http2"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,11 @@ mod common;
 pub mod rt;
 #[cfg(feature = "server")]
 pub mod server;
-#[cfg(feature = "service")]
+#[cfg(all(
+    feature = "service",
+    any(feature = "http1", feature = "http2"),
+    any(feature = "server", feature = "client")
+))]
 pub mod service;
 
 mod error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,10 +12,7 @@ mod common;
 pub mod rt;
 #[cfg(feature = "server")]
 pub mod server;
-#[cfg(all(
-    any(feature = "http1", feature = "http2"),
-    any(feature = "server", feature = "client")
-))]
+#[cfg(feature = "service")]
 pub mod service;
 
 mod error;

--- a/src/service.rs
+++ b/src/service.rs
@@ -9,10 +9,6 @@ use std::{
 use tower::{util::Oneshot, ServiceExt};
 
 /// A tower service converted into a hyper service.
-#[cfg(all(
-    any(feature = "http1", feature = "http2"),
-    any(feature = "server", feature = "client")
-))]
 #[derive(Debug, Copy, Clone)]
 pub struct TowerToHyperService<S> {
     service: S,
@@ -44,10 +40,6 @@ where
 
 pin_project! {
     /// Response future for [`TowerToHyperService`].
-    #[cfg(all(
-        any(feature = "http1", feature = "http2"),
-        any(feature = "server", feature = "client")
-    ))]
     pub struct TowerToHyperServiceFuture<S, R>
     where
         S: tower_service::Service<R>,


### PR DESCRIPTION
The `tower/tower-service` is only used in the `client/client-legacy` feature. If one only needs `server/server-auto` feature, there is no need to include them.

Testing in sigoden/dufs#321,  with this pr, there is a reduction of 0.3 M in the stripped release binary.