### PR TITLE
feat: allow enabling http1/http2 individually

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,14 +19,14 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 hyper = "1.1.0"
-futures-channel = "0.3"
 futures-util = { version = "0.3.16", default-features = false }
 http = "1.0"
 http-body = "1.0.0"
 bytes = "1"
 pin-project-lite = "0.2.4"
+futures-channel = { version = "0.3", optional = true }
 socket2 = { version = "0.5", optional = true, features = ["all"] }
-tracing = { version = "0.1", default-features = false, features = ["std"] }
+tracing = { version = "0.1", default-features = false, features = ["std"], optional = true }
 tokio = { version = "1", optional = true, features = ["net", "rt", "time"] }
 tower-service ={ version = "0.3", optional = true }
 tower = { version = "0.4.1", optional = true, features = ["make", "util"] }
@@ -57,7 +57,7 @@ full = [
     "tokio",
 ]
 
-client = ["hyper/client", "dep:tower", "dep:tower-service"]
+client = ["hyper/client", "dep:tracing", "dep:futures-channel", "dep:tower", "dep:tower-service"]
 client-legacy = ["client"]
 
 server = ["hyper/server"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ authors = ["Sean McArthur <sean@seanmonstar.com>"]
 keywords = ["http", "hyper", "hyperium"]
 categories = ["network-programming", "web-programming::http-client", "web-programming::http-server"]
 edition = "2021"
+resolver = "2"
 
 [package.metadata.docs.rs]
 features = ["full"]

--- a/src/server/conn/mod.rs
+++ b/src/server/conn/mod.rs
@@ -1,4 +1,4 @@
 //! Connection utilities.
 
-#[cfg(feature = "server-auto")]
+#[cfg(any(feature = "http1", feature = "http2"))]
 pub mod auto;


### PR DESCRIPTION
As in the title. Previously we pulled in just the deps for http1 or just the deps for http2. This reenables that.