### PR TITLE
Document the correct default value

### DIFF
--- a/src/server/conn/auto.rs
+++ b/src/server/conn/auto.rs
@@ -597,7 +597,7 @@ impl<E> Http2Builder<'_, E> {
     /// Sets the [`SETTINGS_MAX_CONCURRENT_STREAMS`][spec] option for HTTP2
     /// connections.
     ///
-    /// Default is no limit (`std::u32::MAX`). Passing `None` will do nothing.
+    /// Default is 200. Passing `None` will remove any limit.
     ///
     /// [spec]: https://http2.github.io/http2-spec/#SETTINGS_MAX_CONCURRENT_STREAMS
     pub fn max_concurrent_streams(&mut self, max: impl Into<Option<u32>>) -> &mut Self {


### PR DESCRIPTION
Load testing on our web application caused issues and it looks like it is because of this.

The default value is 200 as you can see from the default instantiation here: https://github.com/hyperium/hyper/blob/1d4ff3597b8e76818c8553dbfa4234cf4208c958/src/proto/h2/server.rs#L66