### PR TITLE
fix(client): no keep-alive always returning an error

### DIFF
--- a/src/client/legacy/client.rs
+++ b/src/client/legacy/client.rs
@@ -382,6 +382,14 @@ where
         &self,
         pool_key: PoolKey,
     ) -> Result<pool::Pooled<PoolClient<B>, PoolKey>, ClientConnectError> {
+        // Return a single connection if pooling is not enabled
+        if !self.pool.is_enabled() {
+            return self
+                .connect_to(pool_key)
+                .await
+                .map_err(ClientConnectError::Normal);
+        }
+
         // This actually races 2 different futures to try to get a ready
         // connection the fastest, and to reduce connection churn.
         //
@@ -1456,7 +1464,6 @@ impl fmt::Debug for Builder {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Builder")
             .field("client_config", &self.client_config)
-            //.field("conn_builder", &self.conn_builder)
             .field("pool_config", &self.pool_config)
             .finish()
     }

--- a/src/client/legacy/pool.rs
+++ b/src/client/legacy/pool.rs
@@ -138,7 +138,7 @@ impl<T, K: Key> Pool<T, K> {
         Pool { inner }
     }
 
-    fn is_enabled(&self) -> bool {
+    pub(crate) fn is_enabled(&self) -> bool {
         self.inner.is_some()
     }
 


### PR DESCRIPTION
fixes https://github.com/hyperium/hyper/issues/3499

This PR fixes the `hyper_util::client::legacy::Client` always returning an error without sending any request.

Found while working on https://github.com/hyperium/hyper-util/pull/77, test for this will be included in the PR.

---

After the change, the code in the issue returns
```rust
Ok(
    Response {
        status: 200,
        version: HTTP/1.0,
        headers: {
            "server": "SimpleHTTP/0.6 Python/3.11.4",
            "date": "Fri, 22 Dec 2023 13:24:20 GMT",
            "content-type": "text/html; charset=utf-8",
            "content-length": "2204",
        },
        body: Body(
            Streaming,
        ),
    },
)
```

instead of `PoolDisabled` error