### PR TITLE
feat: add timer support for `legacy::Pool`

### DIFF
--- a/src/client/legacy/client.rs
+++ b/src/client/legacy/client.rs
@@ -22,7 +22,8 @@ use tracing::{debug, trace, warn};
 use super::connect::HttpConnector;
 use super::connect::{Alpn, Connect, Connected, Connection};
 use super::pool::{self, Ver};
-use crate::common::{lazy as hyper_lazy, Exec, Lazy, SyncWrapper};
+
+use crate::common::{lazy as hyper_lazy, timer, Exec, Lazy, SyncWrapper};
 
 type BoxSendFuture = Pin<Box<dyn Future<Output = ()> + Send>>;
 
@@ -975,6 +976,7 @@ pub struct Builder {
     #[cfg(feature = "http2")]
     h2_builder: hyper::client::conn::http2::Builder<Exec>,
     pool_config: pool::Config,
+    pool_timer: Option<timer::Timer>,
 }
 
 impl Builder {
@@ -999,13 +1001,34 @@ impl Builder {
                 idle_timeout: Some(Duration::from_secs(90)),
                 max_idle_per_host: std::usize::MAX,
             },
+            pool_timer: None,
         }
     }
     /// Set an optional timeout for idle sockets being kept-alive.
+    /// A `Timer` is required for this to take effect
     ///
     /// Pass `None` to disable timeout.
     ///
     /// Default is 90 seconds.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # #[cfg(feature = "tokio")]
+    /// # fn run () {
+    /// use std::time::Duration;
+    /// use hyper_util::client::legacy::Client;
+    /// use hyper_util::rt::{TokioExecutor, TokioTimer};
+    ///
+    /// let client = Client::builder(TokioExecutor::new())
+    ///     .pool_idle_timeout(Duration::from_secs(30))
+    ///     .timer(TokioTimer::new())
+    ///     .build_http();
+    ///
+    /// # let infer: Client<_, http_body_util::Full<bytes::Bytes>> = client;
+    /// # }
+    /// # fn main() {}
+    /// ```
     pub fn pool_idle_timeout<D>(&mut self, val: D) -> &mut Self
     where
         D: Into<Option<Duration>>,
@@ -1374,11 +1397,11 @@ impl Builder {
     /// [`h2::client::Builder::timer`]: https://docs.rs/h2/client/struct.Builder.html#method.timer
     pub fn timer<M>(&mut self, timer: M) -> &mut Self
     where
-        M: Timer + Send + Sync + 'static,
+        M: Timer + Clone + Send + Sync + 'static,
     {
+        self.pool_timer = Some(timer::Timer::new(timer.clone()));
         #[cfg(feature = "http2")]
         self.h2_builder.timer(timer);
-        // TODO(https://github.com/hyperium/hyper/issues/3167) set for pool as well
         self
     }
 
@@ -1447,6 +1470,7 @@ impl Builder {
         B::Data: Send,
     {
         let exec = self.exec.clone();
+        let timer = self.pool_timer.clone();
         Client {
             config: self.client_config,
             exec: exec.clone(),
@@ -1455,7 +1479,7 @@ impl Builder {
             #[cfg(feature = "http2")]
             h2_builder: self.h2_builder.clone(),
             connector,
-            pool: pool::Pool::new(self.pool_config, exec),
+            pool: pool::Pool::new(self.pool_config, exec, timer),
         }
     }
 }

--- a/src/client/legacy/pool.rs
+++ b/src/client/legacy/pool.rs
@@ -422,8 +422,14 @@ impl<T: Poolable, K: Key> PoolInner<T, K> {
         if self.idle_interval_ref.is_some() {
             return;
         }
-        let Some(dur) = self.timeout else { return };
-        let Some(timer) = self.timer.clone() else {
+        let dur = if let Some(dur) = self.timeout {
+            dur
+        } else {
+            return;
+        };
+        let timer = if let Some(timer) = self.timer.clone() {
+            timer
+        } else {
             return;
         };
         let (tx, rx) = oneshot::channel();

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -6,6 +6,7 @@ mod lazy;
 pub(crate) mod rewind;
 #[cfg(feature = "client")]
 mod sync;
+pub(crate) mod timer;
 
 #[cfg(feature = "client")]
 pub(crate) use exec::Exec;

--- a/src/common/timer.rs
+++ b/src/common/timer.rs
@@ -1,0 +1,39 @@
+#![allow(dead_code)]
+
+use std::fmt;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::Duration;
+use std::time::Instant;
+
+use hyper::rt::Sleep;
+
+#[derive(Clone)]
+pub(crate) struct Timer(Arc<dyn hyper::rt::Timer + Send + Sync>);
+
+// =====impl Timer=====
+impl Timer {
+    pub(crate) fn new<T>(inner: T) -> Self
+    where
+        T: hyper::rt::Timer + Send + Sync + 'static,
+    {
+        Self(Arc::new(inner))
+    }
+}
+
+impl fmt::Debug for Timer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Timer").finish()
+    }
+}
+
+impl hyper::rt::Timer for Timer {
+    fn sleep(&self, duration: Duration) -> Pin<Box<dyn Sleep>> {
+        self.0.sleep(duration)
+    }
+
+    fn sleep_until(&self, deadline: Instant) -> Pin<Box<dyn Sleep>> {
+        self.0.sleep_until(deadline)
+    }
+}

--- a/src/common/timer.rs
+++ b/src/common/timer.rs
@@ -1,7 +1,6 @@
 #![allow(dead_code)]
 
 use std::fmt;
-use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;


### PR DESCRIPTION
Addresses https://github.com/hyperium/hyper/issues/3167

Note that previously we're using tokio's `Interval` rather than `Sleep`. This PR tries to emulate the behavior for `Pool` using `Sleep` instead, so that:

1. No extra trait for `Interval`
2. User only needs to supply a `Timer` rather than a `Timer` and also an `Interval`.
