### PR TITLE
feat(http2): add `initial_max_send_streams` method to client builder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ features = ["full"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-hyper = "1.1.0"
+hyper = "1.2.0"
 futures-util = { version = "0.3.16", default-features = false }
 http = "1.0"
 http-body = "1.0.0"
@@ -31,7 +31,7 @@ tower-service ={ version = "0.3", optional = true }
 tower = { version = "0.4.1", optional = true, features = ["make", "util"] }
 
 [dev-dependencies]
-hyper = { version = "1.1.0", features = ["full"] }
+hyper = { version = "1.2.0", features = ["full"] }
 bytes = "1"
 http-body-util = "0.1.0"
 tokio = { version = "1", features = ["macros", "test-util"] }

--- a/src/client/legacy/client.rs
+++ b/src/client/legacy/client.rs
@@ -1291,6 +1291,26 @@ impl Builder {
         self
     }
 
+    /// Sets the initial maximum of locally initiated (send) streams.
+    ///
+    /// This value will be overwritten by the value included in the initial
+    /// SETTINGS frame received from the peer as part of a [connection preface].
+    ///
+    /// Passing `None` will do nothing.
+    ///
+    /// If not set, hyper will use a default.
+    ///
+    /// [connection preface]: https://httpwg.org/specs/rfc9113.html#preface
+    #[cfg(feature = "http2")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
+    pub fn http2_initial_max_send_streams(
+        &mut self,
+        initial: impl Into<Option<usize>>,
+    ) -> &mut Self {
+        self.h2_builder.initial_max_send_streams(initial);
+        self
+    }
+
     /// Sets whether to use an adaptive flow control.
     ///
     /// Enabling this will override the limits set in


### PR DESCRIPTION
This adds `initial_max_send_streams` method to the client builder. This simply calls the method with the same name defined in `hyper::client::conn::http2::Builder`.

Depends on https://github.com/hyperium/hyper/pull/3524

