### PR TITLE
Max pending accept reset streams

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ tower-service ={ version = "0.3", optional = true }
 tower = { version = "0.4.1", optional = true, features = ["make", "util"] }
 
 [dev-dependencies]
-hyper = { version = "1.1.0", features = ["full"] }
+hyper = { version = "1.2.0", features = ["full"] }
 bytes = "1"
 http-body-util = "0.1.0"
 tokio = { version = "1", features = ["macros", "test-util"] }
@@ -75,3 +75,4 @@ __internal_happy_eyeballs_tests = []
 [[example]]
 name = "client"
 required-features = ["client-legacy", "http1", "tokio"]
+

--- a/src/server/conn/auto.rs
+++ b/src/server/conn/auto.rs
@@ -661,6 +661,17 @@ impl<E> Http2Builder<'_, E> {
         Http1Builder { inner: self.inner }
     }
 
+    /// Configures the maximum number of pending reset streams allowed before a GOAWAY will be sent.
+    ///
+    /// This will default to the default value set by the [`h2` crate](https://crates.io/crates/h2).
+    /// As of v0.4.0, it is 20.
+    ///
+    /// See <https://github.com/hyperium/hyper/issues/2877> for more information.
+    pub fn max_pending_accept_reset_streams(&mut self, max: impl Into<Option<usize>>) -> &mut Self {
+        self.inner.http2.max_pending_accept_reset_streams(max);
+        self
+    }
+
     /// Sets the [`SETTINGS_INITIAL_WINDOW_SIZE`][spec] option for HTTP2
     /// stream-level flow control.
     ///


### PR DESCRIPTION
This adds `max_pending_accept_reset_streams` method to the server builder.

Closed: https://github.com/hyperium/hyper/issues/3461
Depends on https://github.com/hyperium/hyper/pull/3507
Continue for: https://github.com/hyperium/hyper-util/pull/78