### PR TITLE
feat: impl From<Http1|Http2> for auto::Builder

### DIFF
--- a/src/server/conn/auto.rs
+++ b/src/server/conn/auto.rs
@@ -113,6 +113,19 @@ impl<E> Builder<E> {
         }
     }
 }
+
+impl<'a, E> From<Http1Builder<'a, E>> for &'a mut Builder<E> {
+    fn from(h1: Http1Builder<'a, E>) -> &'a mut Builder<E> {
+        h1.inner
+    }
+}
+
+impl<'a, E> From<Http2Builder<'a, E>> for &'a mut Builder<E> {
+    fn from(h2: Http2Builder<'a, E>) -> &'a mut Builder<E> {
+        h2.inner
+    }
+}
+
 #[derive(Copy, Clone)]
 enum Version {
     H1,


### PR DESCRIPTION
The motivation is I wanted a way to get back to the main `Builder`, and this seemed to do it. Does it make sense?

cc @davidpdrsn @programatik29 