### PR TITLE
feat: Add a `Error::is_connect()` method

### DIFF
--- a/src/client/legacy/client.rs
+++ b/src/client/legacy/client.rs
@@ -1516,6 +1516,10 @@ impl StdError for Error {
 }
 
 impl Error {
+    pub fn is_connect(&self) -> bool {
+        matches!(self.kind, ErrorKind::Connect)
+    }
+
     fn is_canceled(&self) -> bool {
         matches!(self.kind, ErrorKind::Canceled)
     }

--- a/src/client/legacy/client.rs
+++ b/src/client/legacy/client.rs
@@ -1516,6 +1516,7 @@ impl StdError for Error {
 }
 
 impl Error {
+    /// Returns true if this was an error from `Connect`.
     pub fn is_connect(&self) -> bool {
         matches!(self.kind, ErrorKind::Connect)
     }


### PR DESCRIPTION
It will be useful for reqwest's upgrade to hyper v1.