### PR TITLE
Adds `max_pending_accept_reset_streams` for legacy

### DIFF
--- a/src/client/legacy/client.rs
+++ b/src/client/legacy/client.rs
@@ -1300,7 +1300,7 @@ impl Builder {
         &mut self,
         max: impl Into<Option<usize>>,
     ) -> &mut Self {
-        self.h2_builder.max_pending_accept_reset_streams = max.into();
+        self.h2_builder.max_pending_accept_reset_streams(max.into());
         self
     }
 

--- a/src/client/legacy/client.rs
+++ b/src/client/legacy/client.rs
@@ -1261,6 +1261,22 @@ impl Builder {
         self
     }
 
+    /// Configures the maximum number of pending reset streams allowed before a GOAWAY will be sent.
+    ///
+    /// This will default to the default value set by the [`h2` crate](https://crates.io/crates/h2).
+    /// As of v0.4.0, it is 20.
+    ///
+    /// See <https://github.com/hyperium/hyper/issues/2877> for more information.
+    #[cfg(feature = "http2")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
+    pub fn http2_max_pending_accept_reset_streams(
+        &mut self,
+        max: impl Into<Option<usize>>,
+    ) -> &mut Self {
+        self.h2_builder.max_pending_accept_reset_streams = max.into();
+        self
+    }
+
     /// Sets the [`SETTINGS_INITIAL_WINDOW_SIZE`][spec] option for HTTP2
     /// stream-level flow control.
     ///


### PR DESCRIPTION
Adds this missing function to the legacy client.

#90 was merged with half of #78. This PR is the other half.