### PR TITLE
fix: enable socket2 only for client-legacy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ full = [
 ]
 
 client = ["hyper/client", "dep:tracing", "dep:futures-channel", "dep:tower", "dep:tower-service"]
-client-legacy = ["client"]
+client-legacy = ["client", "dep:socket2"]
 
 server = ["hyper/server"]
 server-auto = ["server", "http1", "http2"]
@@ -67,7 +67,7 @@ service = ["dep:tower", "dep:tower-service"]
 http1 = ["hyper/http1"]
 http2 = ["hyper/http2"]
 
-tokio = ["dep:tokio", "dep:socket2"]
+tokio = ["dep:tokio"]
 
 # internal features used in CI
 __internal_happy_eyeballs_tests = []


### PR DESCRIPTION
`socket2` dependency is only used in the client-legacy.
Current approach had the disadvantage of enabling socket2 even if you don't need it, e.g. a platform that socket2 doesn't support like `wasm-unknown-unknown`