### PR TITLE
feat(server-auto): make http1 and http2 feature optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,12 @@ edition = "2021"
 features = ["full"]
 rustdoc-args = ["--cfg", "docsrs"]
 
+[patch.crates-io]
+hyper = { git = "https://github.com/hyperium/hyper", rev = "refs/pull/3591/head" }
+
 [dependencies]
 hyper = "1.2.0"
-futures-util = { version = "0.3.16", default-features = false }
+futures-util = { version = "0.3.16", default-features = false, optional = true }
 http = "1.0"
 http-body = "1.0.0"
 bytes = "1"
@@ -31,6 +34,7 @@ tower-service ={ version = "0.3", optional = true }
 tower = { version = "0.4.1", optional = true, features = ["make", "util"] }
 
 [dev-dependencies]
+futures-util = { version = "0.3.16", default-features = false }
 hyper = { version = "1.2.0", features = ["full"] }
 bytes = "1"
 http-body-util = "0.1.0"
@@ -57,10 +61,10 @@ full = [
 ]
 
 client = ["hyper/client", "dep:tracing", "dep:futures-channel", "dep:tower", "dep:tower-service"]
-client-legacy = ["client", "dep:socket2"]
+client-legacy = ["client", "dep:futures-util", "dep:socket2"]
 
 server = ["hyper/server"]
-server-auto = ["server", "http1", "http2"]
+server-auto = ["server", "dep:futures-util"]
 
 service = ["dep:tower", "dep:tower-service"]
 
@@ -75,4 +79,3 @@ __internal_happy_eyeballs_tests = []
 [[example]]
 name = "client"
 required-features = ["client-legacy", "http1", "tokio"]
-

--- a/src/server/conn/mod.rs
+++ b/src/server/conn/mod.rs
@@ -1,4 +1,4 @@
 //! Connection utilities.
 
-#[cfg(any(feature = "http1", feature = "http2"))]
+#[cfg(feature = "server-auto")]
 pub mod auto;


### PR DESCRIPTION
Depends on https://github.com/hyperium/hyper/pull/3591. 

This is a breaking change. Uses `server-auto` feature to enable server-auto implementation to treat dependencies finely same as client and client-legacy do.