### PR TITLE
fix: disable default features for dep "tower"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ socket2 = { version = "0.5", optional = true, features = ["all"] }
 tracing = { version = "0.1", default-features = false, features = ["std"], optional = true }
 tokio = { version = "1", optional = true, features = ["net", "rt", "time"] }
 tower-service ={ version = "0.3", optional = true }
-tower = { version = "0.4.1", optional = true, features = ["make", "util"] }
+tower = { version = "0.4.1", optional = true, default-features = false, features = ["make", "util"] }
 
 [dev-dependencies]
 hyper = { version = "1.2.0", features = ["full"] }


### PR DESCRIPTION
`hyper-util` implicitly depends on `tower`'s feature `log` through `default`s, which should not be necessary. They have [long since removed the defaults](https://github.com/tower-rs/tower/commit/5064987ffec4420ef6ea6de649606286370e42bc), but never actually released a new version with that fix.

I have only found this because i upgraded to reqwest 0.12 (from 0.11), which suddenly spammed the logs (which were not setup for tracing yet) with tracing output, but those logs could somehow not be disabled, and finding the cause was quite annoying. This all happened because `tower`'s `log` feature sets `tracing/log`.