### PR TITLE
doc: Fix `TokioIo` doc

### DIFF
--- a/src/rt/tokio.rs
+++ b/src/rt/tokio.rs
@@ -16,8 +16,9 @@ use pin_project_lite::pin_project;
 pub struct TokioExecutor {}
 
 pin_project! {
-    /// A wrapping implementing hyper IO traits for a type that
-    /// implements Tokio's IO traits.
+    /// A wrapper that implements Tokio's IO traits for an inner type that
+    /// implements hyper's IO traits, or vice versa (implements hyper's IO
+    /// traits for a type that implements Tokio's IO traits).
     #[derive(Debug)]
     pub struct TokioIo<T> {
         #[pin]
@@ -62,7 +63,7 @@ impl TokioExecutor {
 // ==== impl TokioIo =====
 
 impl<T> TokioIo<T> {
-    /// Wrap a type implementing Tokio's IO traits.
+    /// Wrap a type implementing Tokio's or hyper's IO traits.
     pub fn new(inner: T) -> Self {
         Self { inner }
     }


### PR DESCRIPTION
The `TokioIo` docs are confusing when a user intends to use it for adapting a hyper IO trait impl to a Tokio IO trait impl. This commit updates the `TokioIo` docs to make clear that it is a bidirectional adapter between Tokio's and hyper's IO traits.