### PR TITLE
feat: impl Connection for TokioIo

### DIFF
--- a/src/client/legacy/connect/http.rs
+++ b/src/client/legacy/connect/http.rs
@@ -438,12 +438,10 @@ where
     }
 }
 
-impl Connection for TokioIo<TcpStream> {
+impl Connection for TcpStream {
     fn connected(&self) -> Connected {
         let connected = Connected::new();
-        if let (Ok(remote_addr), Ok(local_addr)) =
-            (self.inner().peer_addr(), self.inner().local_addr())
-        {
+        if let (Ok(remote_addr), Ok(local_addr)) = (self.peer_addr(), self.local_addr()) {
             connected.extra(HttpInfo {
                 remote_addr,
                 local_addr,
@@ -451,6 +449,17 @@ impl Connection for TokioIo<TcpStream> {
         } else {
             connected
         }
+    }
+}
+
+// Implement `Connection` for generic `TokioIo<T>` so that external crates can
+// implement their own `HttpConnector` with `TokioIo<CustomTcpStream>`.
+impl<T> Connection for TokioIo<T>
+where
+    T: Connection,
+{
+    fn connected(&self) -> Connected {
+        self.inner().connected()
     }
 }
 


### PR DESCRIPTION
Without this implementation, when a downstream crate wants to implement a custom `HttpConnector`, it would have to wrap up an extra layer over `TokioIo<TcpStream>`. Consequently, this would result in a forwarding implementation of `hyper::rt::{Read, Write}` for the new type.

See [here](https://github.com/kvinwang/wapo/commit/9e748d401128101efe05098f740a65b1549771ca) for more detail.