### PR TITLE
Add API for poisoning connections

### DIFF
--- a/src/client/legacy/client.rs
+++ b/src/client/legacy/client.rs
@@ -750,6 +750,10 @@ impl<B> PoolClient<B> {
         }
     }
 
+    fn is_poisoned(&self) -> bool {
+        self.conn_info.poisoned.poisoned()
+    }
+
     fn is_ready(&self) -> bool {
         match self.tx {
             #[cfg(feature = "http1")]
@@ -826,7 +830,7 @@ where
     B: Send + 'static,
 {
     fn is_open(&self) -> bool {
-        self.is_ready()
+        !self.is_poisoned() && self.is_ready()
     }
 
     fn reserve(self) -> pool::Reservation<Self> {

--- a/tests/legacy_client.rs
+++ b/tests/legacy_client.rs
@@ -909,6 +909,7 @@ fn capture_connection_on_client() {
     assert!(captured_conn.connection_metadata().is_some());
 }
 
+#[cfg(not(miri))]
 #[test]
 fn connection_poisoning() {
     use std::sync::atomic::AtomicUsize;

--- a/tests/legacy_client.rs
+++ b/tests/legacy_client.rs
@@ -909,7 +909,6 @@ fn capture_connection_on_client() {
     assert!(captured_conn.connection_metadata().is_some());
 }
 
-#[cfg(not(miri))]
 #[test]
 fn connection_poisoning() {
     use std::sync::atomic::AtomicUsize;
@@ -938,9 +937,9 @@ fn connection_poisoning() {
             let mut buf = [0; 4096];
             loop {
                 if sock.read(&mut buf).expect("read 1") > 0 {
+                    num_requests_tracker.fetch_add(1, Ordering::Relaxed);
                     sock.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
                         .expect("write 1");
-                    num_requests_tracker.fetch_add(1, Ordering::Relaxed);
                 }
             }
         });


### PR DESCRIPTION
This is a port of https://github.com/hyperium/hyper/pull/3145/files + a test.

It introduces a `PoisonPill` atomic onto connection info. When set to true, this prevents the connection from being returned to the pool.