### PR TITLE
bump hyper to v1.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ features = ["full"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-hyper = "1.2.0"
+hyper = "1.3.0"
 futures-util = { version = "0.3.16", default-features = false }
 http = "1.0"
 http-body = "1.0.0"
@@ -31,7 +31,7 @@ tower-service ={ version = "0.3", optional = true }
 tower = { version = "0.4.1", optional = true, default-features = false, features = ["make", "util"] }
 
 [dev-dependencies]
-hyper = { version = "1.2.0", features = ["full"] }
+hyper = { version = "1.3.0", features = ["full"] }
 bytes = "1"
 http-body-util = "0.1.0"
 tokio = { version = "1", features = ["macros", "test-util"] }


### PR DESCRIPTION
closes https://github.com/hyperium/hyper/issues/3662

Bumps hyper to v1.3.0 to include the changes for https://github.com/hyperium/hyper-util/pull/102.

