### PR TITLE
chore(client): move legacy client builder http2 timer config to http2 feature

### DIFF
--- a/src/client/legacy/client.rs
+++ b/src/client/legacy/client.rs
@@ -1458,11 +1458,12 @@ impl Builder {
     /// details.
     ///
     /// [`h2::client::Builder::timer`]: https://docs.rs/h2/client/struct.Builder.html#method.timer
-    pub fn timer<M>(&mut self, timer: M) -> &mut Self
+    #[cfg(feature = "http2")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
+    pub fn http2_timer<M>(&mut self, timer: M) -> &mut Self
     where
         M: Timer + Send + Sync + 'static,
     {
-        #[cfg(feature = "http2")]
         self.h2_builder.timer(timer);
         self
     }


### PR DESCRIPTION
This config API do nothing without `http2` feature. This might be confusing.

As the other `http2` specific config APIs are behind `http2` feature and have `http2_` prefix, unifying it to them will make it easier to be understood.

This is a breaking change.