### PR TITLE
refactor(client): replace deprecated numeric api with primitive one

### DIFF
--- a/src/client/legacy/client.rs
+++ b/src/client/legacy/client.rs
@@ -1004,7 +1004,7 @@ impl Builder {
             h2_builder: hyper::client::conn::http2::Builder::new(exec),
             pool_config: pool::Config {
                 idle_timeout: Some(Duration::from_secs(90)),
-                max_idle_per_host: std::usize::MAX,
+                max_idle_per_host: usize::MAX,
             },
             pool_timer: None,
         }

--- a/src/client/legacy/connect/http.rs
+++ b/src/client/legacy/connect/http.rs
@@ -747,13 +747,13 @@ fn connect(
     }
 
     if let Some(size) = config.send_buffer_size {
-        if let Err(e) = socket.set_send_buffer_size(size.try_into().unwrap_or(std::u32::MAX)) {
+        if let Err(e) = socket.set_send_buffer_size(size.try_into().unwrap_or(u32::MAX)) {
             warn!("tcp set_buffer_size error: {}", e);
         }
     }
 
     if let Some(size) = config.recv_buffer_size {
-        if let Err(e) = socket.set_recv_buffer_size(size.try_into().unwrap_or(std::u32::MAX)) {
+        if let Err(e) = socket.set_recv_buffer_size(size.try_into().unwrap_or(u32::MAX)) {
             warn!("tcp set_recv_buffer_size error: {}", e);
         }
     }


### PR DESCRIPTION
Replaces deprecated numeric api with primitive one.