### PR TITLE
chore: update to pnet_datalink 0.35.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ tokio-test = "0.4"
 pretty_env_logger = "0.5"
 
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dev-dependencies]
-pnet_datalink = "0.34.0"
+pnet_datalink = "0.35.0"
 
 [features]
 default = []


### PR DESCRIPTION
Updates to the latest version of `pnet_datalink`.

https://github.com/libpnet/libpnet/releases/tag/v0.35.0