### PR TITLE
fix: remove unnecesary receiver field from GracefulShutdown

### DIFF
--- a/src/server/graceful.rs
+++ b/src/server/graceful.rs
@@ -43,7 +43,6 @@ impl GracefulShutdown {
     /// This returns a `Future` which will complete once all watched
     /// connections have shutdown.
     pub async fn shutdown(self) {
-        // drop the rx immediately, or else it will hold us up
         let Self { tx } = self;
 
         // signal all the watched futures about the change

--- a/src/server/graceful.rs
+++ b/src/server/graceful.rs
@@ -19,19 +19,18 @@ use tokio::sync::watch;
 /// A graceful shutdown utility
 pub struct GracefulShutdown {
     tx: watch::Sender<()>,
-    rx: watch::Receiver<()>,
 }
 
 impl GracefulShutdown {
     /// Create a new graceful shutdown helper.
     pub fn new() -> Self {
-        let (tx, rx) = watch::channel(());
-        Self { tx, rx }
+        let (tx, _) = watch::channel(());
+        Self { tx }
     }
 
     /// Wrap a future for graceful shutdown watching.
     pub fn watch<C: GracefulConnection>(&self, conn: C) -> impl Future<Output = C::Output> {
-        let mut rx = self.rx.clone();
+        let mut rx = self.tx.subscribe();
         GracefulConnectionFuture::new(conn, async move {
             let _ = rx.changed().await;
             // hold onto the rx until the watched future is completed
@@ -45,8 +44,7 @@ impl GracefulShutdown {
     /// connections have shutdown.
     pub async fn shutdown(self) {
         // drop the rx immediately, or else it will hold us up
-        let Self { tx, rx } = self;
-        drop(rx);
+        let Self { tx } = self;
 
         // signal all the watched futures about the change
         let _ = tx.send(());


### PR DESCRIPTION
This PR removes the unnecesary `watch::Receiver<()>` field from the `GracefulShutdown` struct.
The receiver field is unnecesary since a Receiver can be obtained with `Sender::subscribe()`.

This reduces the size of the struct from 24 to 8.

After this is merged we can think if its worth it to enable `Clone` of the `GracefulShutdown`, which will produce a more flexible api for consumers.
