### PR TITLE
Sync documentation for hyper_util::server::conn::auto::Http1Builder::header_read_timeout with hyper's hyper::server::conn::http1::Builder::header_read_timeout.

### DIFF
--- a/src/server/conn/auto.rs
+++ b/src/server/conn/auto.rs
@@ -695,8 +695,8 @@ impl<E> Http1Builder<'_, E> {
     ///
     /// Pass `None` to disable.
     ///
-    /// Default is 30 seconds.
-    pub fn header_read_timeout(&mut self, read_timeout: Duration) -> &mut Self {
+    /// Default is currently 30 seconds, but do not depend on that.
+    pub fn header_read_timeout(&mut self, read_timeout: impl Into<Option<Duration>>) -> &mut Self {
         self.inner.http1.header_read_timeout(read_timeout);
         self
     }

--- a/src/server/conn/auto.rs
+++ b/src/server/conn/auto.rs
@@ -690,7 +690,12 @@ impl<E> Http1Builder<'_, E> {
     /// Set a timeout for reading client request headers. If a client does not
     /// transmit the entire header within this time, the connection is closed.
     ///
-    /// Default is None.
+    /// Requires a [`Timer`] set by [`Http1Builder::timer`] to take effect. Panics if `header_read_timeout` is configured
+    /// without a [`Timer`].
+    ///
+    /// Pass `None` to disable.
+    ///
+    /// Default is 30 seconds.
     pub fn header_read_timeout(&mut self, read_timeout: Duration) -> &mut Self {
         self.inner.http1.header_read_timeout(read_timeout);
         self


### PR DESCRIPTION
I think the default of 30 seconds, and the commentary about needing to set `Timer` to avoid panics are true for `hyper_util::server::conn::auto::Builder`?  I copied documentation from Hyper here: https://github.com/hyperium/hyper/blob/master/src/server/conn/http1.rs#L311-L323

A possibly larger question - should `auto::Builder` do something to setup a `Timer` by default for http1/http2 builders?  Already `auto::Builder::new` takes an executor parameter, should this also take a timer parameter?

Thanks! 😃 
