### PR TITLE
chore(ci): Use tokio 1.38.1 in MSRV check

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -68,6 +68,10 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
+      - name: Make sure tokio 1.38.1 is used for MSRV
+        run: |
+          cargo update
+          cargo update --package tokio --precise 1.38.1
       - run: cargo check --features full
 
   miri:


### PR DESCRIPTION
Uses `tokio` 1.38.1 in the MSRV checking as `tokio` 1.39 bumps its MSRV to 1.70.

https://github.com/tokio-rs/tokio/releases/tag/tokio-1.39.0