### PR TITLE
chore(dependencies): bump tower to v0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ socket2 = { version = "0.5", optional = true, features = ["all"] }
 tracing = { version = "0.1", default-features = false, features = ["std"], optional = true }
 tokio = { version = "1", optional = true, default-features = false  }
 tower-service ={ version = "0.3", optional = true }
-tower = { version = "0.4.1", optional = true, default-features = false, features = ["make", "util"] }
+tower = { version = "0.5", optional = true, default-features = false, features = ["make", "util"] }
 
 [dev-dependencies]
 hyper = { version = "1.4.0", features = ["full"] }


### PR DESCRIPTION
Upgrades to the recently released [tower v0.5](https://github.com/tower-rs/tower/releases/tag/tower-0.5.0)