### PR TITLE
feat(server): add support for `idle_timeout`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ categories = ["network-programming", "web-programming::http-client", "web-progra
 edition = "2021"
 rust-version = "1.63"
 
+[patch.crates-io]
+hyper = { git = "https://github.com/finnbear/hyper", branch = "idle_timeout" }
+
 [package.metadata.docs.rs]
 features = ["full"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/src/server/conn/auto.rs
+++ b/src/server/conn/auto.rs
@@ -701,6 +701,21 @@ impl<E> Http1Builder<'_, E> {
         self
     }
 
+    /// Set a timeout for idle time between requests. If a client does not
+    /// transmit another request within this time after receiving the last
+    /// response, the connection is closed.
+    ///
+    /// Requires a [`Timer`] set by [`Builder::timer`] to take effect. Panics if `idle_timeout` is configured
+    /// without a [`Timer`].
+    ///
+    /// Pass `None` to disable.
+    ///
+    /// Default is currently 120 seconds, but do not depend on that.
+    pub fn idle_timeout(&mut self, idle_timeout: impl Into<Option<Duration>>) -> &mut Self {
+        self.inner.http1.idle_timeout(idle_timeout);
+        self
+    }
+
     /// Set whether HTTP/1 connections should try to use vectored writes,
     /// or always flatten into a single buffer.
     ///


### PR DESCRIPTION
See https://github.com/hyperium/hyper/pull/3743

Draft until #3743 is merged.

## Testing
- [x] Tested in my app

```toml
# Cargo.toml

[patch.crates-io]
hyper = { git = "https://github.com/finnbear/hyper", branch = "idle_timeout" }
hyper-util = { git = "https://github.com/finnbear/hyper-util", branch = "idle_timeout" }
```