### PR TITLE
feat(client): Expose `http2::builder::max_header_list_size` in the client builder

### DIFF
--- a/src/client/legacy/client.rs
+++ b/src/client/legacy/client.rs
@@ -1387,6 +1387,16 @@ impl Builder {
         self
     }
 
+    /// Sets the max size of received header frames for HTTP2.
+    ///
+    /// Default is currently 16KB, but can change.
+    #[cfg(feature = "http2")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
+    pub fn max_header_list_size(&mut self, max: u32) -> &mut Self {
+        self.h2_builder.max_header_list_size(max);
+        self
+    }
+
     /// Sets an interval for HTTP2 Ping frames should be sent to keep a
     /// connection alive.
     ///

--- a/src/client/legacy/client.rs
+++ b/src/client/legacy/client.rs
@@ -1392,7 +1392,7 @@ impl Builder {
     /// Default is currently 16KB, but can change.
     #[cfg(feature = "http2")]
     #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
-    pub fn max_header_list_size(&mut self, max: u32) -> &mut Self {
+    pub fn http2_max_header_list_size(&mut self, max: u32) -> &mut Self {
         self.h2_builder.max_header_list_size(max);
         self
     }


### PR DESCRIPTION
Currently the max size of received header frames for HTTP2 responses defaults to the 16KB when creating a hyper client. The 16KB default is defined in [hyper::proto::h2::DEFAULT_MAX_HEADER_LIST_SIZE](https://github.com/hyperium/hyper/blob/master/src/proto/h2/client.rs#L54).

This PR adds support to override this default value, to allow for custom limits of the maximum header sizes being received in HTTP/2 responses.

Adjusting the limit is already supported for incoming requests with [hyper_util::server::conn::auto::Http2Builder::max_header_list_size](https://docs.rs/hyper-util/latest/hyper_util/server/conn/auto/struct.Http2Builder.html#method.max_header_list_size).