### PR TITLE
chore: Fix test warning

### DIFF
--- a/src/common/rewind.rs
+++ b/src/common/rewind.rs
@@ -16,35 +16,13 @@ pub(crate) struct Rewind<T> {
 }
 
 impl<T> Rewind<T> {
-    #[cfg(test)]
-    pub(crate) fn new(io: T) -> Self {
-        Rewind {
-            pre: None,
-            inner: io,
-        }
-    }
-
-    #[allow(dead_code)]
+    #[cfg(all(feature = "server", any(feature = "http1", feature = "http2")))]
     pub(crate) fn new_buffered(io: T, buf: Bytes) -> Self {
         Rewind {
             pre: Some(buf),
             inner: io,
         }
     }
-
-    #[cfg(test)]
-    pub(crate) fn rewind(&mut self, bs: Bytes) {
-        debug_assert!(self.pre.is_none());
-        self.pre = Some(bs);
-    }
-
-    // pub(crate) fn into_inner(self) -> (T, Bytes) {
-    //     (self.inner, self.pre.unwrap_or_else(Bytes::new))
-    // }
-
-    // pub(crate) fn get_mut(&mut self) -> &mut T {
-    //     &mut self.inner
-    // }
 }
 
 impl<T> Read for Rewind<T>


### PR DESCRIPTION
On current master (`30f38c8d8728ee99a2194bc7a2c5f556cb6a0a3a`) with Rust 1.82 (`rustc 1.82.0 (f6e511eec 2024-10-15)`, `cargo 1.82.0 (8f40fc59f 2024-08-21)`), running `cargo check --all-features --tests` emits the following warning:

```
warning: associated items `new` and `rewind` are never used
  --> src/common/rewind.rs:20:19
   |
18 | impl<T> Rewind<T> {
   | ----------------- associated items in this implementation
19 |     #[cfg(test)]
20 |     pub(crate) fn new(io: T) -> Self {
   |                   ^^^
...
36 |     pub(crate) fn rewind(&mut self, bs: Bytes) {
   |                   ^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default

warning: `hyper-util` (lib test) generated 1 warning
```

This PR fixes that and also does some other, opportunistic cleanup in the same file:

- Removes unused `new` and `rewind` methods
- Changes the `#[allow(dead_code)]` annotation on `new_buffered` to more specific feature-gating
- Removes commented out code which hasn't been touched in a long time

Note on the second point: from searching through the project for the string `new_buffered`, it is called solely from `hyper-util/src/server/conn/auto/mod.rs` on lines 144, 150, and 285.

- The first two call sites are annotated with `#[cfg(feature = "http1")]` and `#[cfg(feature = "http2")]` respectively
- The `server::conn::auto` module itself is feature-gated with `#[cfg(any(feature = "http1", feature = "http2"))]`
- The `server` module is of course feature-gated with `#[cfg(feature = "server")]`.

I confirmed that in this branch that the following commands succeed without warnings:

```sh
cargo check
cargo check --all-features
cargo check --all-features --tests
cargo check --features http1
cargo check --features http2
cargo check --features http1,http2
cargo check --features http1,http2,server
cargo test --all-features
```
