### PR TITLE
chore: Fix docs warnings when docs built with `--all-features`

### DIFF
--- a/src/client/legacy/connect/capture.rs
+++ b/src/client/legacy/connect/capture.rs
@@ -19,6 +19,8 @@ pub struct CaptureConnection {
 /// [`capture_connection`] allows a caller to capture the returned [`Connected`] structure as soon
 /// as the connection is established.
 ///
+/// [`Connection`]: crate::client::legacy::connect::Connection
+///
 /// *Note*: If establishing a connection fails, [`CaptureConnection::connection_metadata`] will always return none.
 ///
 /// # Examples

--- a/src/client/legacy/connect/dns.rs
+++ b/src/client/legacy/connect/dns.rs
@@ -2,8 +2,7 @@
 //!
 //! This module contains:
 //!
-//! - A [`GaiResolver`](GaiResolver) that is the default resolver for the
-//!   `HttpConnector`.
+//! - A [`GaiResolver`] that is the default resolver for the `HttpConnector`.
 //! - The `Name` type used as an argument to custom resolvers.
 //!
 //! # Resolvers are `Service`s

--- a/src/client/legacy/connect/http.rs
+++ b/src/client/legacy/connect/http.rs
@@ -168,7 +168,7 @@ impl HttpConnector {
 impl<R> HttpConnector<R> {
     /// Construct a new HttpConnector.
     ///
-    /// Takes a [`Resolver`](crate::client::connect::dns#resolvers-are-services) to handle DNS lookups.
+    /// Takes a [`Resolver`](crate::client::legacy::connect::dns#resolvers-are-services) to handle DNS lookups.
     pub fn new_with_resolver(resolver: R) -> HttpConnector<R> {
         HttpConnector {
             config: Arc::new(Config {

--- a/src/server/conn/auto/mod.rs
+++ b/src/server/conn/auto/mod.rs
@@ -110,6 +110,8 @@ impl<E> Builder<E> {
     /// Only accepts HTTP/2
     ///
     /// Does not do anything if used with [`serve_connection_with_upgrades`]
+    ///
+    /// [`serve_connection_with_upgrades`]: Builder::serve_connection_with_upgrades
     #[cfg(feature = "http2")]
     pub fn http2_only(mut self) -> Self {
         assert!(self.version.is_none());
@@ -120,6 +122,8 @@ impl<E> Builder<E> {
     /// Only accepts HTTP/1
     ///
     /// Does not do anything if used with [`serve_connection_with_upgrades`]
+    ///
+    /// [`serve_connection_with_upgrades`]: Builder::serve_connection_with_upgrades
     #[cfg(feature = "http1")]
     pub fn http1_only(mut self) -> Self {
         assert!(self.version.is_none());
@@ -169,6 +173,8 @@ impl<E> Builder<E> {
     /// Note that if you ever want to use [`hyper::upgrade::Upgraded::downcast`]
     /// with this crate, you'll need to use [`hyper_util::server::conn::auto::upgrade::downcast`]
     /// instead. See the documentation of the latter to understand why.
+    ///
+    /// [`hyper_util::server::conn::auto::upgrade::downcast`]: crate::server::conn::auto::upgrade::downcast
     pub fn serve_connection_with_upgrades<I, S, B>(
         &self,
         io: I,

--- a/src/server/conn/auto/upgrade.rs
+++ b/src/server/conn/auto/upgrade.rs
@@ -12,8 +12,10 @@ use crate::common::rewind::Rewind;
 ///
 /// On success, returns the downcasted parts. On error, returns the Upgraded back.
 /// This is a kludge to work around the fact that the machinery provided by
-/// [`hyper_util::server::con::auto`] wraps the inner `T` with a private type
+/// [`hyper_util::server::conn::auto`] wraps the inner `T` with a private type
 /// that is not reachable from outside the crate.
+///
+/// [`hyper_util::server::conn::auto`]: crate::server::conn::auto
 ///
 /// This kludge will be removed when this machinery is added back to the main
 /// `hyper` code.


### PR DESCRIPTION
On current master (`a63603772ee1bc98957cf86eb3a904ed2357ba36`) with Rust 1.82 (`rustc 1.82.0 (f6e511eec 2024-10-15)`, `cargo 1.82.0 (8f40fc59f 2024-08-21)`), although both running `cargo doc` and running `cargo check --all-features` works without warnings, running `cargo doc --all-features` emits the following warnings:

<details><summary>Warnings</summary>

```
warning: unresolved link to `crate::client::connect::dns`
   --> src/client/legacy/connect/http.rs:171:30
    |
171 |     /// Takes a [`Resolver`](crate::client::connect::dns#resolvers-are-services) to handle DNS lookups.
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no item named `connect` in module `client`
    |
    = note: `#[warn(rustdoc::broken_intra_doc_links)]` on by default

warning: unresolved link to `Connection`
  --> src/client/legacy/connect/capture.rs:18:86
   |
18 | /// When making a request with Hyper, the underlying connection must implement the [`Connection`] trait.
   |                                                                                      ^^^^^^^^^^ no item named `Connection` in scope
   |
   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`

warning: unresolved link to `hyper_util::server::con::auto`
  --> src/server/conn/auto/upgrade.rs:15:7
   |
15 | /// [`hyper_util::server::con::auto`] wraps the inner `T` with a private type
   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no item named `hyper_util` in scope

warning: unresolved link to `serve_connection_with_upgrades`
   --> src/server/conn/auto/mod.rs:112:45
    |
112 |     /// Does not do anything if used with [`serve_connection_with_upgrades`]
    |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no item named `serve_connection_with_upgrades` in scope
    |
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`

warning: unresolved link to `serve_connection_with_upgrades`
   --> src/server/conn/auto/mod.rs:122:45
    |
122 |     /// Does not do anything if used with [`serve_connection_with_upgrades`]
    |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no item named `serve_connection_with_upgrades` in scope
    |
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`

warning: unresolved link to `hyper_util::server::conn::auto::upgrade::downcast`
   --> src/server/conn/auto/mod.rs:170:47
    |
170 |     /// with this crate, you'll need to use [`hyper_util::server::conn::auto::upgrade::downcast`]
    |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no item named `hyper_util` in scope

warning: redundant explicit link target
 --> src/client/legacy/connect/dns.rs:5:25
  |
5 | //! - A [`GaiResolver`](GaiResolver) that is the default resolver for the
  |          -------------  ^^^^^^^^^^^ explicit target is redundant
  |          |
  |          because label contains path that resolves to same destination
  |
  = note: when a link's destination is not specified,
          the label is used to resolve intra-doc links
  = note: `#[warn(rustdoc::redundant_explicit_links)]` on by default
help: remove explicit link target
  |
5 | //! - A [`GaiResolver`] that is the default resolver for the
  |         ~~~~~~~~~~~~~~~

warning: `hyper-util` (lib doc) generated 7 warnings
```

</details>

This PR fixes all such warnings.