### PR TITLE
chore(ci): Use hashbrown 0.15.0 in MSRV check

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -64,16 +64,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install Rust (${{ matrix.rust }})
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ matrix.rust }}
+      - uses: dtolnay/rust-toolchain@stable
       - name: Pin some dependencies for MSRV
         run: |
           cargo update
           cargo update --package tokio --precise 1.38.1
           cargo update --package tokio-util --precise 0.7.11
           cargo update --package hashbrown --precise 0.15.0
+      - name: Install Rust (${{ matrix.rust }})
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
       - run: cargo check --features full
 
   miri:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -73,6 +73,7 @@ jobs:
           cargo update
           cargo update --package tokio --precise 1.38.1
           cargo update --package tokio-util --precise 0.7.11
+          cargo update --package hashbrown --precise 0.15.0
       - run: cargo check --features full
 
   miri:


### PR DESCRIPTION
Uses `hashbrown` 0.15.0 in MSRV checking as `hashbrown` 0.15.1 bumps its MSRV to 1.65.