### PR TITLE
feat(server): support `auto_date_header`, `max_local_error_reset_streams`, and `ignore_invalid_headers`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ features = ["full"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-hyper = "1.4.0"
+hyper = "1.6.0"
 futures-util = { version = "0.3.16", default-features = false }
 http = "1.0"
 http-body = "1.0.0"

--- a/src/server/conn/auto/mod.rs
+++ b/src/server/conn/auto/mod.rs
@@ -855,7 +855,7 @@ impl<E> Http2Builder<'_, E> {
     /// This is not advised, as it can potentially expose servers to DOS vulnerabilities.
     ///
     /// See <https://rustsec.org/advisories/RUSTSEC-2024-0003.html> for more information.
-    pub fn max_local_error_reset_streams(mut self, max: impl Into<Option<usize>>) -> Self {
+    pub fn max_local_error_reset_streams(&mut self, max: impl Into<Option<usize>>) -> &mut Self {
         self.inner.http2.max_local_error_reset_streams(max);
         self
     }

--- a/src/server/conn/auto/mod.rs
+++ b/src/server/conn/auto/mod.rs
@@ -629,6 +629,16 @@ impl<E> Http1Builder<'_, E> {
         Http2Builder { inner: self.inner }
     }
 
+    /// Set whether the `date` header should be included in HTTP responses.
+    ///
+    /// Note that including the `date` header is recommended by RFC 7231.
+    ///
+    /// Default is true.
+    pub fn auto_date_header(&mut self, enabled: bool) -> &mut Self {
+        self.inner.http1.auto_date_header(enabled);
+        self
+    }
+
     /// Set whether HTTP/1 connections should support half-closures.
     ///
     /// Clients can chose to shutdown their write-side while waiting
@@ -837,6 +847,19 @@ impl<E> Http2Builder<'_, E> {
         self
     }
 
+    /// Configures the maximum number of local reset streams allowed before a GOAWAY will be sent.
+    ///
+    /// If not set, hyper will use a default, currently of 1024.
+    ///
+    /// If `None` is supplied, hyper will not apply any limit.
+    /// This is not advised, as it can potentially expose servers to DOS vulnerabilities.
+    ///
+    /// See <https://rustsec.org/advisories/RUSTSEC-2024-0003.html> for more information.
+    pub fn max_local_error_reset_streams(mut self, max: impl Into<Option<usize>>) -> Self {
+        self.inner.http2.max_local_error_reset_streams(max);
+        self
+    }
+
     /// Sets the [`SETTINGS_INITIAL_WINDOW_SIZE`][spec] option for HTTP2
     /// stream-level flow control.
     ///
@@ -953,6 +976,16 @@ impl<E> Http2Builder<'_, E> {
         M: Timer + Send + Sync + 'static,
     {
         self.inner.http2.timer(timer);
+        self
+    }
+
+    /// Set whether the `date` header should be included in HTTP responses.
+    ///
+    /// Note that including the `date` header is recommended by RFC 7231.
+    ///
+    /// Default is true.
+    pub fn auto_date_header(&mut self, enabled: bool) -> &mut Self {
+        self.inner.http2.auto_date_header(enabled);
         self
     }
 

--- a/src/server/conn/auto/mod.rs
+++ b/src/server/conn/auto/mod.rs
@@ -671,6 +671,18 @@ impl<E> Http1Builder<'_, E> {
         self
     }
 
+    /// Set whether HTTP/1 connections will silently ignored malformed header lines.
+    ///
+    /// If this is enabled and a header line does not start with a valid header
+    /// name, or does not include a colon at all, the line will be silently ignored
+    /// and no error will be reported.
+    ///
+    /// Default is false.
+    pub fn ignore_invalid_headers(&mut self, enabled: bool) -> &mut Self {
+        self.inner.http1.ignore_invalid_headers(enabled);
+        self
+    }
+
     /// Set whether to support preserving original header cases.
     ///
     /// Currently, this will record the original cases received, and store them


### PR DESCRIPTION
This PR adds `hyper-util` builder support for functions that were previously missing:
- HTTP/1 `ignore_invalid_headers` (`hyper` 1.6.0)
- HTTP/1 `auto_date_header` (`hyper` 1.4.0)
- HTTP/2 `auto_date_header` (`hyper` 1.4.0)
- HTTP/2 `max_local_error_reset_streams` (`hyper` ~~1.2.0~~ 1.6.0)

Function signatures, function order, and function documentation are copied from `hyper`.

~~**Draft because blocked on: https://github.com/hyperium/hyper/pull/3820**~~