### PR TITLE
Expose legacy error kinds

### DIFF
--- a/src/client/legacy/client.rs
+++ b/src/client/legacy/client.rs
@@ -54,14 +54,14 @@ struct Config {
 
 /// Client errors
 pub struct Error {
-    kind: ErrorKind,
+    pub kind: ErrorKind,
     source: Option<Box<dyn StdError + Send + Sync>>,
     #[cfg(any(feature = "http1", feature = "http2"))]
     connect_info: Option<Connected>,
 }
 
 #[derive(Debug)]
-enum ErrorKind {
+pub enum ErrorKind {
     Canceled,
     ChannelClosed,
     Connect,


### PR DESCRIPTION
Sometimes we might want to retry a request if for instance we have a partial write/read and server has dropped connection.
This PR allows us to match on the error kinds to determine further action.