### PR TITLE
builder: expose methods for determining if HTTP/1.1 or HTTP/2 support are enabled

### DIFF
--- a/src/server/conn/auto/mod.rs
+++ b/src/server/conn/auto/mod.rs
@@ -139,7 +139,7 @@ impl<E> Builder<E> {
             #[cfg(feature = "http2")]
             Some(Version::H2) => false,
             #[cfg(any(feature = "http1", feature = "http2"))]
-            _ => true
+            _ => true,
         }
     }
 
@@ -151,7 +151,7 @@ impl<E> Builder<E> {
             #[cfg(feature = "http2")]
             Some(Version::H2) => true,
             #[cfg(any(feature = "http1", feature = "http2"))]
-            _ => true
+            _ => true,
         }
     }
 

--- a/src/server/conn/auto/mod.rs
+++ b/src/server/conn/auto/mod.rs
@@ -131,6 +131,30 @@ impl<E> Builder<E> {
         self
     }
 
+    /// Returns `true` if this builder can serve an HTTP/1.1-based connection.
+    pub fn is_http1_available(&self) -> bool {
+        match self.version {
+            #[cfg(feature = "http1")]
+            Some(Version::H1) => true,
+            #[cfg(feature = "http2")]
+            Some(Version::H2) => false,
+            #[cfg(any(feature = "http1", feature = "http2"))]
+            _ => true
+        }
+    }
+
+    /// Returns `true` if this builder can serve an HTTP/2-based connection.
+    pub fn is_http2_available(&self) -> bool {
+        match self.version {
+            #[cfg(feature = "http1")]
+            Some(Version::H1) => false,
+            #[cfg(feature = "http2")]
+            Some(Version::H2) => true,
+            #[cfg(any(feature = "http1", feature = "http2"))]
+            _ => true
+        }
+    }
+
     /// Bind a connection together with a [`Service`].
     pub fn serve_connection<I, S, B>(&self, io: I, service: S) -> Connection<'_, I, S, E>
     where


### PR DESCRIPTION
## Context

When utilizing TLS, a user must know if they have their server configured to handle HTTP/1.1 and/or HTTP/2 to properly determine which protocols can be negotiated over ALPN.

This PR adds two new methods to `hyper_util::server::conn::auto::Builder`: `is_http1_available` and `is_http2_available`, which tie back to the inner version value used to determine how to serve a connection. In exposing these, users can now programmatically build the ALPN protocol list rather than having to hardcode it, potentially ending up with a mismatch between the hardcoded list and the actual feature flags enabled for `hyper`/`hyper-util`.

