### PR TITLE
fix(tracing): propagate span context

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ service = ["dep:tower-service"]
 http1 = ["hyper/http1"]
 http2 = ["hyper/http2"]
 
-tokio = ["dep:tokio", "tokio/net", "tokio/rt", "tokio/time"]
+tokio = ["dep:tokio", "tokio/net", "tokio/rt", "tokio/time", "dep:tracing"]
 
 # internal features used in CI
 __internal_happy_eyeballs_tests = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ full = [
     "http1",
     "http2",
     "tokio",
+    "tracing",
 ]
 
 client = ["hyper/client", "dep:tracing", "dep:futures-channel", "dep:tower-service"]
@@ -69,7 +70,9 @@ service = ["dep:tower-service"]
 http1 = ["hyper/http1"]
 http2 = ["hyper/http2"]
 
-tokio = ["dep:tokio", "tokio/net", "tokio/rt", "tokio/time", "dep:tracing"]
+tokio = ["dep:tokio", "tokio/net", "tokio/rt", "tokio/time"]
+
+tracing = ["dep:tracing"]
 
 # internal features used in CI
 __internal_happy_eyeballs_tests = []

--- a/src/rt/tokio.rs
+++ b/src/rt/tokio.rs
@@ -9,6 +9,8 @@ use std::{
 
 use hyper::rt::{Executor, Sleep, Timer};
 use pin_project_lite::pin_project;
+
+#[cfg(feature = "tracing")]
 use tracing::instrument::Instrument;
 
 /// Future executor that utilises `tokio` threads.
@@ -50,7 +52,11 @@ where
     Fut::Output: Send + 'static,
 {
     fn execute(&self, fut: Fut) {
+        #[cfg(feature = "tracing")]
         tokio::spawn(fut.in_current_span());
+
+        #[cfg(not(feature = "tracing"))]
+        tokio::spawn(fut);
     }
 }
 

--- a/src/rt/tokio.rs
+++ b/src/rt/tokio.rs
@@ -9,6 +9,7 @@ use std::{
 
 use hyper::rt::{Executor, Sleep, Timer};
 use pin_project_lite::pin_project;
+use tracing::instrument::Instrument;
 
 /// Future executor that utilises `tokio` threads.
 #[non_exhaustive]
@@ -49,7 +50,7 @@ where
     Fut::Output: Send + 'static,
 {
     fn execute(&self, fut: Fut) {
-        tokio::spawn(fut);
+        tokio::spawn(fut.in_current_span());
     }
 }
 


### PR DESCRIPTION
Hi Sean! :wave: 

The tracing span context set in consumers of the `TokioExecutor` is sometimes lost (if the task is run in a different thread). This change adds a call to `in_current_span()` to preserve it.

As a side-effect, it adds a dependency on tracing for the tokio feature. Should I instead allow the new behavior only if tracing is enabled? Or use a separate `TracingExecutor` for this?