### PR TITLE
chore(tokio): warn on dead code

### DIFF
--- a/src/rt/tokio.rs
+++ b/src/rt/tokio.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)]
 //! Tokio IO integration for hyper
 use std::{
     future::Future,


### PR DESCRIPTION
there is a module-wide allowance for dead code that seems to be a holdover from when this was initially being written.

removing this does not unearth any warnings, and ideally any future additions can be explicitly, and more narrowly, annotated accordingly if need be.