### PR TITLE
chore(client/legacy): remove unused `PoolClient::is_closed()`

### DIFF
--- a/src/client/legacy/client.rs
+++ b/src/client/legacy/client.rs
@@ -758,15 +758,6 @@ impl<B> PoolClient<B> {
             PoolTx::Http2(ref tx) => tx.is_ready(),
         }
     }
-
-    fn is_closed(&self) -> bool {
-        match self.tx {
-            #[cfg(feature = "http1")]
-            PoolTx::Http1(ref tx) => tx.is_closed(),
-            #[cfg(feature = "http2")]
-            PoolTx::Http2(ref tx) => tx.is_closed(),
-        }
-    }
 }
 
 impl<B: Body + 'static> PoolClient<B> {


### PR DESCRIPTION
this function is not used, and a warning is observed when this crate is built with e.g. `--all-features`.

this commit removes this unused method from the `PoolClient<B>` type.