### PR TITLE
feat(rt/tokio): additive tokio and hyper i/o adaptors

### DIFF
--- a/src/rt/tokio.rs
+++ b/src/rt/tokio.rs
@@ -13,6 +13,11 @@ use pin_project_lite::pin_project;
 #[cfg(feature = "tracing")]
 use tracing::instrument::Instrument;
 
+pub use self::{with_hyper_io::WithHyperIo, with_tokio_io::WithTokioIo};
+
+mod with_hyper_io;
+mod with_tokio_io;
+
 /// Future executor that utilises `tokio` threads.
 #[non_exhaustive]
 #[derive(Default, Debug, Clone)]

--- a/src/rt/tokio/with_hyper_io.rs
+++ b/src/rt/tokio/with_hyper_io.rs
@@ -1,0 +1,170 @@
+use pin_project_lite::pin_project;
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+pin_project! {
+    /// Extends an underlying [`tokio`] I/O with [`hyper`] I/O implementations.
+    ///
+    /// This implements [`Read`] and [`Write`] given an inner type that implements [`AsyncRead`]
+    /// and [`AsyncWrite`], respectively.
+    #[derive(Debug)]
+    pub struct WithHyperIo<I> {
+        #[pin]
+        inner: I,
+    }
+}
+
+// ==== impl WithHyperIo =====
+
+impl<I> WithHyperIo<I> {
+    /// Wraps the inner I/O in an [`WithHyperIo<I>`]
+    pub fn new(inner: I) -> Self {
+        Self { inner }
+    }
+
+    /// Returns a reference to the inner type.
+    pub fn inner(&self) -> &I {
+        &self.inner
+    }
+
+    /// Returns a mutable reference to the inner type.
+    pub fn inner_mut(&mut self) -> &mut I {
+        &mut self.inner
+    }
+
+    /// Consumes this wrapper and returns the inner type.
+    pub fn into_inner(self) -> I {
+        self.inner
+    }
+}
+
+/// [`WithHyperIo<I>`] is [`Read`] if `I` is [`AsyncRead`].
+///
+/// [`AsyncRead`]: tokio::io::AsyncRead
+/// [`Read`]: hyper::rt::Read
+impl<I> hyper::rt::Read for WithHyperIo<I>
+where
+    I: tokio::io::AsyncRead,
+{
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        mut buf: hyper::rt::ReadBufCursor<'_>,
+    ) -> Poll<Result<(), std::io::Error>> {
+        let n = unsafe {
+            let mut tbuf = tokio::io::ReadBuf::uninit(buf.as_mut());
+            match tokio::io::AsyncRead::poll_read(self.project().inner, cx, &mut tbuf) {
+                Poll::Ready(Ok(())) => tbuf.filled().len(),
+                other => return other,
+            }
+        };
+
+        unsafe {
+            buf.advance(n);
+        }
+        Poll::Ready(Ok(()))
+    }
+}
+
+/// [`WithHyperIo<I>`] is [`Write`] if `I` is [`AsyncWrite`].
+///
+/// [`AsyncWrite`]: tokio::io::AsyncWrite
+/// [`Write`]: hyper::rt::Write
+impl<I> hyper::rt::Write for WithHyperIo<I>
+where
+    I: tokio::io::AsyncWrite,
+{
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, std::io::Error>> {
+        tokio::io::AsyncWrite::poll_write(self.project().inner, cx, buf)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), std::io::Error>> {
+        tokio::io::AsyncWrite::poll_flush(self.project().inner, cx)
+    }
+
+    fn poll_shutdown(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), std::io::Error>> {
+        tokio::io::AsyncWrite::poll_shutdown(self.project().inner, cx)
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        tokio::io::AsyncWrite::is_write_vectored(&self.inner)
+    }
+
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[std::io::IoSlice<'_>],
+    ) -> Poll<Result<usize, std::io::Error>> {
+        tokio::io::AsyncWrite::poll_write_vectored(self.project().inner, cx, bufs)
+    }
+}
+
+/// [`WithHyperIo<I>`] exposes its inner `I`'s [`AsyncRead`] implementation.
+///
+/// [`AsyncRead`]: tokio::io::AsyncRead
+impl<I> tokio::io::AsyncRead for WithHyperIo<I>
+where
+    I: tokio::io::AsyncRead,
+{
+    #[inline]
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> Poll<Result<(), std::io::Error>> {
+        self.project().inner.poll_read(cx, buf)
+    }
+}
+
+/// [`WithHyperIo<I>`] exposes its inner `I`'s [`AsyncWrite`] implementation.
+///
+/// [`AsyncWrite`]: tokio::io::AsyncWrite
+impl<I> tokio::io::AsyncWrite for WithHyperIo<I>
+where
+    I: tokio::io::AsyncWrite,
+{
+    #[inline]
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, std::io::Error>> {
+        self.project().inner.poll_write(cx, buf)
+    }
+
+    #[inline]
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), std::io::Error>> {
+        self.project().inner.poll_flush(cx)
+    }
+
+    #[inline]
+    fn poll_shutdown(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), std::io::Error>> {
+        self.project().inner.poll_shutdown(cx)
+    }
+
+    #[inline]
+    fn is_write_vectored(&self) -> bool {
+        self.inner.is_write_vectored()
+    }
+
+    #[inline]
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[std::io::IoSlice<'_>],
+    ) -> Poll<Result<usize, std::io::Error>> {
+        self.project().inner.poll_write_vectored(cx, bufs)
+    }
+}

--- a/src/rt/tokio/with_tokio_io.rs
+++ b/src/rt/tokio/with_tokio_io.rs
@@ -1,0 +1,178 @@
+use pin_project_lite::pin_project;
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+pin_project! {
+    /// Extends an underlying [`hyper`] I/O with [`tokio`] I/O implementations.
+    ///
+    /// This implements [`AsyncRead`] and [`AsyncWrite`] given an inner type that implements
+    /// [`Read`] and [`Write`], respectively.
+    #[derive(Debug)]
+    pub struct WithTokioIo<I> {
+        #[pin]
+        inner: I,
+    }
+}
+
+// ==== impl WithTokioIo =====
+
+/// [`WithTokioIo<I>`] is [`AsyncRead`] if `I` is [`Read`].
+///
+/// [`AsyncRead`]: tokio::io::AsyncRead
+/// [`Read`]: hyper::rt::Read
+impl<I> tokio::io::AsyncRead for WithTokioIo<I>
+where
+    I: hyper::rt::Read,
+{
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        tbuf: &mut tokio::io::ReadBuf<'_>,
+    ) -> Poll<Result<(), std::io::Error>> {
+        //let init = tbuf.initialized().len();
+        let filled = tbuf.filled().len();
+        let sub_filled = unsafe {
+            let mut buf = hyper::rt::ReadBuf::uninit(tbuf.unfilled_mut());
+
+            match hyper::rt::Read::poll_read(self.project().inner, cx, buf.unfilled()) {
+                Poll::Ready(Ok(())) => buf.filled().len(),
+                other => return other,
+            }
+        };
+
+        let n_filled = filled + sub_filled;
+        // At least sub_filled bytes had to have been initialized.
+        let n_init = sub_filled;
+        unsafe {
+            tbuf.assume_init(n_init);
+            tbuf.set_filled(n_filled);
+        }
+
+        Poll::Ready(Ok(()))
+    }
+}
+
+/// [`WithTokioIo<I>`] is [`AsyncWrite`] if `I` is [`Write`].
+///
+/// [`AsyncWrite`]: tokio::io::AsyncWrite
+/// [`Write`]: hyper::rt::Write
+impl<I> tokio::io::AsyncWrite for WithTokioIo<I>
+where
+    I: hyper::rt::Write,
+{
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, std::io::Error>> {
+        hyper::rt::Write::poll_write(self.project().inner, cx, buf)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), std::io::Error>> {
+        hyper::rt::Write::poll_flush(self.project().inner, cx)
+    }
+
+    fn poll_shutdown(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), std::io::Error>> {
+        hyper::rt::Write::poll_shutdown(self.project().inner, cx)
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        hyper::rt::Write::is_write_vectored(&self.inner)
+    }
+
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[std::io::IoSlice<'_>],
+    ) -> Poll<Result<usize, std::io::Error>> {
+        hyper::rt::Write::poll_write_vectored(self.project().inner, cx, bufs)
+    }
+}
+
+/// [`WithTokioIo<I>`] exposes its inner `I`'s [`Write`] implementation.
+///
+/// [`Write`]: hyper::rt::Write
+impl<I> hyper::rt::Write for WithTokioIo<I>
+where
+    I: hyper::rt::Write,
+{
+    #[inline]
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, std::io::Error>> {
+        self.project().inner.poll_write(cx, buf)
+    }
+
+    #[inline]
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), std::io::Error>> {
+        self.project().inner.poll_flush(cx)
+    }
+
+    #[inline]
+    fn poll_shutdown(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), std::io::Error>> {
+        self.project().inner.poll_shutdown(cx)
+    }
+
+    #[inline]
+    fn is_write_vectored(&self) -> bool {
+        self.inner.is_write_vectored()
+    }
+
+    #[inline]
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[std::io::IoSlice<'_>],
+    ) -> Poll<Result<usize, std::io::Error>> {
+        self.project().inner.poll_write_vectored(cx, bufs)
+    }
+}
+
+impl<I> WithTokioIo<I> {
+    /// Wraps the inner I/O in an [`WithTokioIo<I>`]
+    pub fn new(inner: I) -> Self {
+        Self { inner }
+    }
+
+    /// Returns a reference to the inner type.
+    pub fn inner(&self) -> &I {
+        &self.inner
+    }
+
+    /// Returns a mutable reference to the inner type.
+    pub fn inner_mut(&mut self) -> &mut I {
+        &mut self.inner
+    }
+
+    /// Consumes this wrapper and returns the inner type.
+    pub fn into_inner(self) -> I {
+        self.inner
+    }
+}
+
+/// [`WithTokioIo<I>`] exposes its inner `I`'s [`Read`] implementation.
+///
+/// [`Read`]: hyper::rt::Read
+impl<I> hyper::rt::Read for WithTokioIo<I>
+where
+    I: hyper::rt::Read,
+{
+    #[inline]
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: hyper::rt::ReadBufCursor<'_>,
+    ) -> Poll<Result<(), std::io::Error>> {
+        self.project().inner.poll_read(cx, buf)
+    }
+}


### PR DESCRIPTION
this commit introduces two new i/o adaptors, akin to `rt::tokio::TokioIo<I>`.

see this small program demonstrating the motivation for this:

```rust
 #![allow(unreachable_code, unused_variables, dead_code)]

 use {
     hyper::rt::{Read, Write},
     hyper_util::rt::TokioIo,
     tokio::io::{AsyncRead, AsyncWrite},
     tokio::net::TcpStream,
 };

 fn is_tokio_io<I>(_: &I)
 where
     I: AsyncRead + AsyncWrite,
 {
 }

 fn is_hyper_io<I>(_: &I)
 where
     I: Read + Write,
 {
 }

 fn check_io_impls() {
     // `I: AsyncRead + AsyncWrite` does not implement hyper's `Read` and `Write`.
     let stream: TcpStream = todo!();
     is_tokio_io(&stream);
     // is_hyper_io(&stream); does not compile

     // `TokioIo<I: AsyncRead + AsyncWrite>` does not implement `tokio::io` traits.
     let stream: TokioIo<TcpStream> = TokioIo::new(stream);
     // is_tokio_io(&stream); does not compile
     is_hyper_io(&stream);

     // `TokioIo<TokioIo<I: AsyncRead + AsyncWrite>>` does not implement hyper's `Read` and `Write`.
     let stream: TokioIo<TokioIo<TcpStream>> = TokioIo::new(stream);
     is_tokio_io(&stream);
     // is_hyper_io(&stream); does not compile
 }

 fn main() {}
```

`TokioIo<I>` is not an adaptor that is additive with respect to its inner i/o transport. if it implements hyper's i/o, the wrapped type will implement tokio's _at the expense of hyper's_, and vice versa.

this is often fine for simple programs, but this "switching" approach can interfere with larger applications' ability to make use of middleware that is generic across different kinds of i/o streams.

this commit introduces types that allow a caller to _add_ `Read` or `Write` implementations to tokio readers and writers, or inversely, `AsyncRead` and `AsyncWrite` implementations to hyper readers and writers.