### PR TITLE
feat(client): add `proxy::Socks` legacy util

### DIFF
--- a/src/client/legacy/connect/mod.rs
+++ b/src/client/legacy/connect/mod.rs
@@ -74,6 +74,8 @@ pub mod dns;
 #[cfg(feature = "tokio")]
 mod http;
 
+pub mod proxy;
+
 pub(crate) mod capture;
 pub use capture::{capture_connection, CaptureConnection};
 

--- a/src/client/legacy/connect/proxy/mod.rs
+++ b/src/client/legacy/connect/proxy/mod.rs
@@ -1,5 +1,7 @@
 //! Proxy helpers
 
 mod tunnel;
+mod socks;
 
 pub use self::tunnel::Tunnel;
+pub use self::socks::Socks;

--- a/src/client/legacy/connect/proxy/mod.rs
+++ b/src/client/legacy/connect/proxy/mod.rs
@@ -1,0 +1,5 @@
+//! Proxy helpers
+
+mod tunnel;
+
+pub use self::tunnel::Tunnel;

--- a/src/client/legacy/connect/proxy/mod.rs
+++ b/src/client/legacy/connect/proxy/mod.rs
@@ -1,7 +1,7 @@
 //! Proxy helpers
 
-mod tunnel;
 mod socks;
+mod tunnel;
 
-pub use self::tunnel::Tunnel;
 pub use self::socks::Socks;
+pub use self::tunnel::Tunnel;

--- a/src/client/legacy/connect/proxy/socks.rs
+++ b/src/client/legacy/connect/proxy/socks.rs
@@ -1,0 +1,596 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+use http::Uri;
+use hyper::rt::{Read, Write};
+use tower_service::Service;
+
+use pin_project_lite::pin_project;
+
+/// Tunnel Proxy via SOCKS 5 CONNECT
+#[derive(Debug)]
+pub struct Socks<C> {
+    auth: Option<(String, String)>,
+    inner: C,
+    proxy_dst: Uri,
+}
+
+#[derive(Debug)]
+pub enum SocksError<C> {
+    Inner(C),
+    Io(std::io::Error),
+
+    Parsing(ParsingError),
+    Serialize(SerializeError),
+
+    Auth(AuthError),
+    Command(Status),
+
+    MissingHost,
+    MissingPort,
+    HostTooLong,
+}
+
+#[derive(Debug)]
+pub enum AuthError {
+    Unsupported,
+    MethodMismatch,
+    Failed,
+}
+
+pin_project! {
+    pub struct Handshaking<F, T, E> {
+        #[pin]
+        fut: BoxHandshaking<T, E>,
+        _marker: std::marker::PhantomData<F>
+    }
+}
+
+type BoxHandshaking<T, E> = Pin<Box<dyn Future<Output = Result<T, SocksError<E>>> + Send>>;
+
+impl<C> Socks<C> {
+    /// Create a new SOCKS CONNECT service
+    pub fn new(proxy_dst: Uri, connector: C) -> Self {
+        Self {
+            auth: None,
+            inner: connector,
+            proxy_dst,
+        }
+    }
+
+    /// Use User/Pass authentication method during handshake
+    pub fn with_auth(mut self, user: String, pass: String) -> Self {
+        self.auth = Some((user, pass));
+        self
+    }
+}
+
+impl<C> Service<Uri> for Socks<C>
+where
+    C: Service<Uri>,
+    C::Future: Send + 'static,
+    C::Response: Read + Write + Unpin + Send + 'static,
+    C::Error: Send + 'static,
+{
+    type Response = C::Response;
+    type Error = SocksError<C::Error>;
+    type Future = Handshaking<C::Future, C::Response, C::Error>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx).map_err(SocksError::Inner)
+    }
+
+    fn call(&mut self, dst: Uri) -> Self::Future {
+        let conn = self.inner.call(self.proxy_dst.clone());
+        let auth = self.auth.clone();
+
+        Handshaking {
+            fut: Box::pin(async move {
+                handshake(
+                    conn.await.map_err(SocksError::Inner)?,
+                    dst.host().ok_or(SocksError::MissingHost)?.to_string(),
+                    dst.port().ok_or(SocksError::MissingPort)?.as_u16(),
+                    auth,
+                )
+                .await
+            }),
+
+            _marker: Default::default(),
+        }
+    }
+}
+
+impl<F, T, E> Future for Handshaking<F, T, E>
+where
+    F: Future<Output = Result<T, E>>,
+{
+    type Output = Result<T, SocksError<E>>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.project().fut.poll(cx)
+    }
+}
+
+async fn handshake<T, E>(
+    mut conn: T,
+    host: String,
+    port: u16,
+    auth: Option<(String, String)>,
+) -> Result<T, SocksError<E>>
+where
+    T: Read + Write + Unpin,
+{
+    let address = match host.parse::<IpAddr>() {
+        Ok(IpAddr::V4(v4)) => Address::V4(v4, port),
+        Ok(IpAddr::V6(v6)) => Address::V6(v6, port),
+        Err(_) if host.len() <= 255 => Address::Domain(host, port),
+        Err(_) => return Err(SocksError::HostTooLong),
+    };
+
+    let method = if let Some(_) = auth {
+        AuthMethod::UserPass
+    } else {
+        AuthMethod::NoAuth
+    };
+
+    let mut buf: [u8; 513] = [0; 513];
+
+    // Write message
+    let req = NegotiationReq(method);
+    let n = req.write_to_buf(&mut buf[..])?;
+    crate::rt::write_all(&mut conn, &buf[..n]).await?;
+
+    // Read response
+    let res: NegotiationRes = read_message(&mut conn, &mut buf).await?;
+
+    if res.0 == AuthMethod::NoneAcceptable {
+        return Err(AuthError::Unsupported.into());
+    }
+
+    if res.0 != method {
+        return Err(AuthError::MethodMismatch.into());
+    }
+
+    // Optional authentication flow
+    if res.0 == AuthMethod::UserPass {
+        // Write message
+        let (user, pass) = auth.unwrap();
+        let req = AuthenticationReq(&user, &pass);
+        let n = req.write_to_buf(&mut buf[..])?;
+        crate::rt::write_all(&mut conn, &buf[..n]).await?;
+
+        // Read response
+        let res: AuthenticationRes = read_message(&mut conn, &mut buf).await?;
+
+        if !res.0 {
+            return Err(AuthError::Failed.into());
+        }
+    }
+
+    // Send proxy request
+    let req = ProxyReq(address);
+    let n = req.write_to_buf(&mut buf[..])?;
+    crate::rt::write_all(&mut conn, &buf[..n]).await?;
+
+    // Read proxy status
+    let res: ProxyRes = read_message(&mut conn, &mut buf).await?;
+
+    if res.0 == Status::Success {
+        Ok(conn)
+    } else {
+        Err(res.0.into())
+    }
+}
+
+async fn read_message<T, M, C>(mut conn: &mut T, buf: &mut [u8]) -> Result<M, SocksError<C>>
+where
+    T: Read + Unpin,
+    M: for<'a> TryFrom<&'a [u8], Error = ParsingError>,
+{
+    let mut n = 0;
+    loop {
+        let read = crate::rt::read(&mut conn, buf).await?;
+
+        if read == 0 {
+            return Err(
+                std::io::Error::new(std::io::ErrorKind::UnexpectedEof, "unexpected eof").into(),
+            );
+        }
+
+        n += read;
+        match M::try_from(&buf[..n]) {
+            Err(ParsingError::Incomplete) => continue,
+            Err(err) => return Err(err.into()),
+
+            Ok(res) => return Ok(res),
+        }
+    }
+}
+
+use messages::*;
+mod messages {
+    use super::*;
+
+    #[derive(Debug)]
+    pub struct NegotiationReq(pub AuthMethod);
+    #[derive(Debug)]
+    pub struct NegotiationRes(pub AuthMethod);
+
+    #[derive(Debug)]
+    pub struct AuthenticationReq<'a>(pub &'a str, pub &'a str);
+    #[derive(Debug)]
+    pub struct AuthenticationRes(pub bool);
+
+    #[derive(Debug)]
+    pub struct ProxyReq(pub Address);
+    #[derive(Debug)]
+    pub struct ProxyRes(pub Status);
+
+    #[repr(u8)]
+    #[derive(Debug, Copy, Clone, PartialEq)]
+    pub enum AuthMethod {
+        NoAuth = 0x00,
+        UserPass = 0x02,
+        NoneAcceptable = 0xFF,
+    }
+
+    #[derive(Debug)]
+    pub enum Address {
+        V4(Ipv4Addr, u16),
+        V6(Ipv6Addr, u16),
+        Domain(String, u16),
+    }
+
+    #[derive(Debug, Copy, Clone, PartialEq)]
+    pub enum Status {
+        Success,
+        GeneralServerFailure,
+        ConnectionNotAllowed,
+        NetworkUnreachable,
+        HostUnreachable,
+        ConnectionRefused,
+        TtlExpired,
+        CommandNotSupported,
+        AddressTypeNotSupported,
+    }
+
+    #[derive(Debug)]
+    pub enum ParsingError {
+        Incomplete,
+        Other,
+    }
+
+    #[derive(Debug)]
+    pub enum SerializeError {
+        WouldOverflow,
+    }
+
+    impl TryFrom<u8> for AuthMethod {
+        type Error = ParsingError;
+
+        fn try_from(byte: u8) -> Result<Self, Self::Error> {
+            Ok(match byte {
+                0x00 => Self::NoAuth,
+                0x02 => Self::UserPass,
+                0xFF => Self::NoneAcceptable,
+
+                _ => return Err(ParsingError::Other),
+            })
+        }
+    }
+
+    impl From<NegotiationReq> for [u8; 3] {
+        fn from(req: NegotiationReq) -> Self {
+            [0x05, 0x01, req.0 as u8]
+        }
+    }
+
+    use bytes::{Buf, BufMut};
+
+    impl NegotiationReq {
+        ///  +----+----------+----------+
+        /// |VER | NMETHODS | METHODS  |
+        /// +----+----------+----------+
+        /// | 1  |    1     | 1 to 255 |
+        /// +----+----------+----------+
+        pub fn write_to_buf<B: BufMut>(&self, mut buf: B) -> Result<usize, SerializeError> {
+            if buf.remaining_mut() < 3 {
+                return Err(SerializeError::WouldOverflow);
+            }
+
+            buf.put_u8(0x05); // Version
+            buf.put_u8(0x01); // Number of authentication methods
+            buf.put_u8(self.0 as u8); // Authentication method
+
+            Ok(3)
+        }
+    }
+
+    impl TryFrom<&[u8]> for NegotiationRes {
+        type Error = ParsingError;
+
+        /// +----+--------+
+        /// |VER | METHOD |
+        /// +----+--------+
+        /// | 1  |   1    |
+        /// +----+--------+
+        fn try_from(mut buf: &[u8]) -> Result<Self, ParsingError> {
+            use bytes::Buf;
+
+            if buf.remaining() < 2 {
+                return Err(ParsingError::Incomplete);
+            }
+
+            if buf.get_u8() != 0x05 {
+                return Err(ParsingError::Other);
+            }
+
+            let method = buf.get_u8().try_into()?;
+            Ok(Self(method))
+        }
+    }
+
+    impl AuthenticationReq<'_> {
+        /// +----+------+----------+------+----------+
+        /// |VER | ULEN |  UNAME   | PLEN |  PASSWD  |
+        /// +----+------+----------+------+----------+
+        /// | 1  |  1   | 1 to 255 |  1   | 1 to 255 |
+        /// +----+------+----------+------+----------+
+        pub fn write_to_buf<B: BufMut>(&self, mut buf: B) -> Result<usize, SerializeError> {
+            if buf.remaining_mut() < 3 + self.0.len() + self.1.len() {
+                return Err(SerializeError::WouldOverflow);
+            }
+
+            buf.put_u8(0x01); // Version
+
+            buf.put_u8(self.0.len() as u8); // Username length (guarenteed to be 255 or less)
+            buf.put_slice(self.0.as_bytes()); // Username
+
+            buf.put_u8(self.1.len() as u8); // Password length (guarenteed to be 255 or less)
+            buf.put_slice(self.1.as_bytes()); // Password
+
+            Ok(3 + self.0.len() + self.1.len())
+        }
+    }
+
+    impl TryFrom<&[u8]> for AuthenticationRes {
+        type Error = ParsingError;
+
+        /// +----+--------+
+        /// |VER | STATUS |
+        /// +----+--------+
+        /// | 1  |   1    |
+        /// +----+--------+
+        fn try_from(mut buf: &[u8]) -> Result<Self, ParsingError> {
+            use bytes::Buf;
+
+            if buf.remaining() < 2 {
+                return Err(ParsingError::Incomplete);
+            }
+
+            if buf.get_u8() != 0x01 {
+                return Err(ParsingError::Other);
+            }
+
+            if buf.get_u8() == 0 {
+                Ok(Self(true))
+            } else {
+                Ok(Self(false))
+            }
+        }
+    }
+
+    impl ProxyReq {
+        /// +----+-----+-------+------+----------+----------+
+        /// |VER | CMD |  RSV  | ATYP | DST.ADDR | DST.PORT |
+        /// +----+-----+-------+------+----------+----------+
+        /// | 1  |  1  | X'00' |  1   | Variable |    2     |
+        /// +----+-----+-------+------+----------+----------+
+        pub fn write_to_buf<B: BufMut>(&self, mut buf: B) -> Result<usize, SerializeError> {
+            let addr_len = match self.0 {
+                Address::V4(_, _) => 1 + 4 + 2,
+                Address::V6(_, _) => 1 + 16 + 2,
+                Address::Domain(ref domain, _) => 1 + 1 + domain.len() + 2,
+            };
+
+            if buf.remaining_mut() < 3 + addr_len {
+                return Err(SerializeError::WouldOverflow);
+            }
+
+            buf.put_u8(0x05); // Version
+            buf.put_u8(0x01); // TCP tunneling command
+            buf.put_u8(0x00); // Reserved
+            let _ = self.0.write_to_buf(buf); // Address
+
+            Ok(3 + addr_len)
+        }
+    }
+
+    impl TryFrom<&[u8]> for ProxyRes {
+        type Error = ParsingError;
+
+        /// +----+-----+-------+------+----------+----------+
+        /// |VER | REP |  RSV  | ATYP | BND.ADDR | BND.PORT |
+        /// +----+-----+-------+------+----------+----------+
+        /// | 1  |  1  | X'00' |  1   | Variable |    2     |
+        /// +----+-----+-------+------+----------+----------+
+        fn try_from(mut buf: &[u8]) -> Result<Self, ParsingError> {
+            if buf.remaining() < 2 {
+                return Err(ParsingError::Incomplete);
+            }
+
+            // VER
+            if buf.get_u8() != 0x05 {
+                return Err(ParsingError::Other);
+            }
+
+            // REP
+            let status = buf.get_u8().try_into()?;
+
+            // RSV
+            if buf.get_u8() != 0x00 {
+                return Err(ParsingError::Other);
+            }
+
+            // ATYP + ADDR
+            Address::try_from(buf)?;
+
+            Ok(Self(status))
+        }
+    }
+
+    impl Address {
+        pub fn write_to_buf<B: BufMut>(&self, mut buf: B) -> Result<usize, SerializeError> {
+            match self {
+                Self::V4(ip, port) => {
+                    if buf.remaining_mut() < 1 + 4 + 2 {
+                        return Err(SerializeError::WouldOverflow);
+                    }
+
+                    buf.put_u8(0x01);
+                    buf.put_slice(&ip.octets());
+                    buf.put_u16(*port); // Network Order/BigEndian for port
+
+                    Ok(7)
+                }
+
+                Self::V6(ip, port) => {
+                    if buf.remaining_mut() < 1 + 16 + 2 {
+                        return Err(SerializeError::WouldOverflow);
+                    }
+
+                    buf.put_u8(0x04);
+                    buf.put_slice(&ip.octets());
+                    buf.put_u16(*port); // Network Order/BigEndian for port
+
+                    Ok(19)
+                }
+
+                Self::Domain(domain, port) => {
+                    if buf.remaining_mut() < 1 + 1 + domain.len() + 2 {
+                        return Err(SerializeError::WouldOverflow);
+                    }
+
+                    buf.put_u8(0x03);
+                    buf.put_u8(domain.len() as u8); // Guarenteed to be less than 255
+                    buf.put_slice(domain.as_bytes());
+                    buf.put_u16(*port);
+
+                    Ok(4 + domain.len())
+                }
+            }
+        }
+    }
+
+    impl TryFrom<&[u8]> for Address {
+        type Error = ParsingError;
+
+        fn try_from(mut buf: &[u8]) -> Result<Self, Self::Error> {
+            use bytes::Buf;
+
+            if buf.remaining() < 2 {
+                return Err(ParsingError::Incomplete);
+            }
+
+            Ok(match buf.get_u8() {
+                0x01 => {
+                    let mut ip = [0; 4];
+
+                    if buf.remaining() < 6 {
+                        return Err(ParsingError::Incomplete);
+                    }
+
+                    buf.copy_to_slice(&mut ip);
+                    let port = buf.get_u16();
+
+                    Self::V4(ip.into(), port)
+                }
+
+                0x03 => {
+                    let len = buf.get_u8();
+
+                    if len == 0 {
+                        return Err(ParsingError::Other);
+                    } else if buf.remaining() < (len as usize) + 2 {
+                        return Err(ParsingError::Incomplete);
+                    }
+
+                    let domain = std::str::from_utf8(&buf[..len as usize])
+                        .map_err(|_| ParsingError::Other)?
+                        .to_string();
+
+                    let port = buf.get_u16();
+
+                    Self::Domain(domain, port)
+                }
+
+                0x04 => {
+                    let mut ip = [0; 16];
+
+                    if buf.remaining() < 6 {
+                        return Err(ParsingError::Incomplete);
+                    }
+                    buf.copy_to_slice(&mut ip);
+                    let port = buf.get_u16();
+
+                    Self::V6(ip.into(), port)
+                }
+
+                _ => return Err(ParsingError::Other),
+            })
+        }
+    }
+
+    impl TryFrom<u8> for Status {
+        type Error = ParsingError;
+
+        fn try_from(byte: u8) -> Result<Self, Self::Error> {
+            Ok(match byte {
+                0x00 => Status::Success,
+
+                0x01 => Status::GeneralServerFailure,
+                0x02 => Status::ConnectionNotAllowed,
+                0x03 => Status::NetworkUnreachable,
+                0x04 => Status::HostUnreachable,
+                0x05 => Status::ConnectionRefused,
+                0x06 => Status::TtlExpired,
+                0x07 => Status::CommandNotSupported,
+                0x08 => Status::AddressTypeNotSupported,
+                _ => return Err(ParsingError::Other),
+            })
+        }
+    }
+}
+
+impl<C> From<std::io::Error> for SocksError<C> {
+    fn from(err: std::io::Error) -> Self {
+        Self::Io(err)
+    }
+}
+
+impl<C> From<ParsingError> for SocksError<C> {
+    fn from(err: ParsingError) -> Self {
+        Self::Parsing(err)
+    }
+}
+
+impl<C> From<AuthError> for SocksError<C> {
+    fn from(err: AuthError) -> Self {
+        Self::Auth(err)
+    }
+}
+
+impl<C> From<Status> for SocksError<C> {
+    fn from(err: Status) -> Self {
+        Self::Command(err)
+    }
+}
+
+impl<C> From<SerializeError> for SocksError<C> {
+    fn from(err: SerializeError) -> Self {
+        Self::Serialize(err)
+    }
+}

--- a/src/client/legacy/connect/proxy/tunnel.rs
+++ b/src/client/legacy/connect/proxy/tunnel.rs
@@ -1,0 +1,181 @@
+use std::future::Future;
+use std::marker::{PhantomData, Unpin};
+use std::pin::Pin;
+use std::task::{self, Poll};
+
+use http::{HeaderValue, Uri};
+use hyper::rt::{Read, Write};
+use pin_project_lite::pin_project;
+use tower_service::Service;
+
+/// Tunnel Proxy via HTTP CONNECT
+#[derive(Debug)]
+pub struct Tunnel<C> {
+    auth: Option<HeaderValue>,
+    inner: C,
+    proxy_dst: Uri,
+}
+
+#[derive(Debug)]
+pub enum TunnelError<C> {
+    Inner(C),
+    Io(std::io::Error),
+    MissingHost,
+    ProxyAuthRequired,
+    ProxyHeadersTooLong,
+    TunnelUnexpectedEof,
+    TunnelUnsuccessful,
+}
+
+pin_project! {
+    // Not publicly exported (so missing_docs doesn't trigger).
+    //
+    // We return this `Future` instead of the `Pin<Box<dyn Future>>` directly
+    // so that users don't rely on it fitting in a `Pin<Box<dyn Future>>` slot
+    // (and thus we can change the type in the future).
+    #[must_use = "futures do nothing unless polled"]
+    #[allow(missing_debug_implementations)]
+    pub struct Tunneling<F, T, E> {
+        #[pin]
+        fut: BoxTunneling<T, E>,
+        _marker: PhantomData<F>,
+    }
+}
+
+type BoxTunneling<T, E> = Pin<Box<dyn Future<Output = Result<T, TunnelError<E>>> + Send>>;
+
+impl<C> Tunnel<C> {
+    /// Create a new Tunnel service.
+    pub fn new(proxy_dst: Uri, connector: C) -> Self {
+        Self {
+            auth: None,
+            inner: connector,
+            proxy_dst,
+        }
+    }
+
+    /// Add `proxy-authorization` header value to the CONNECT request.
+    pub fn with_auth(mut self, mut auth: HeaderValue) -> Self {
+        // just in case the user forgot
+        auth.set_sensitive(true);
+        self.auth = Some(auth);
+        self
+    }
+}
+
+impl<C> Service<Uri> for Tunnel<C>
+where
+    C: Service<Uri>,
+    C::Future: Send + 'static,
+    C::Response: Read + Write + Unpin + Send + 'static,
+    C::Error: Send + 'static,
+{
+    type Response = C::Response;
+    type Error = TunnelError<C::Error>;
+    type Future = Tunneling<C::Future, C::Response, C::Error>;
+
+    fn poll_ready(&mut self, cx: &mut task::Context<'_>) -> Poll<Result<(), Self::Error>> {
+        futures_util::ready!(self.inner.poll_ready(cx)).map_err(TunnelError::Inner)?;
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, dst: Uri) -> Self::Future {
+        let connecting = self.inner.call(self.proxy_dst.clone());
+
+        Tunneling {
+            fut: Box::pin(async move {
+                let conn = connecting.await.map_err(TunnelError::Inner)?;
+                tunnel(
+                    conn,
+                    dst.host().ok_or(TunnelError::MissingHost)?,
+                    dst.port().map(|p| p.as_u16()).unwrap_or(443),
+                    None,
+                    None,
+                )
+                .await
+            }),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<F, T, E> Future for Tunneling<F, T, E>
+where
+    F: Future<Output = Result<T, E>>,
+{
+    type Output = Result<T, TunnelError<E>>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
+        self.project().fut.poll(cx)
+    }
+}
+
+async fn tunnel<T, E>(
+    mut conn: T,
+    host: &str,
+    port: u16,
+    user_agent: Option<HeaderValue>,
+    auth: Option<HeaderValue>,
+) -> Result<T, TunnelError<E>>
+where
+    T: Read + Write + Unpin,
+{
+    let mut buf = format!(
+        "\
+         CONNECT {host}:{port} HTTP/1.1\r\n\
+         Host: {host}:{port}\r\n\
+         "
+    )
+    .into_bytes();
+
+    // user-agent
+    if let Some(user_agent) = user_agent {
+        buf.extend_from_slice(b"User-Agent: ");
+        buf.extend_from_slice(user_agent.as_bytes());
+        buf.extend_from_slice(b"\r\n");
+    }
+
+    // proxy-authorization
+    if let Some(value) = auth {
+        //log::debug!("tunnel to {host}:{port} using basic auth");
+        buf.extend_from_slice(b"Proxy-Authorization: ");
+        buf.extend_from_slice(value.as_bytes());
+        buf.extend_from_slice(b"\r\n");
+    }
+
+    // headers end
+    buf.extend_from_slice(b"\r\n");
+
+    crate::rt::write_all(&mut conn, &buf)
+        .await
+        .map_err(TunnelError::Io)?;
+
+    let mut buf = [0; 8192];
+    let mut pos = 0;
+
+    loop {
+        let n = crate::rt::read(&mut conn, &mut buf[pos..])
+            .await
+            .map_err(TunnelError::Io)?;
+
+        if n == 0 {
+            return Err(TunnelError::TunnelUnexpectedEof);
+        }
+        pos += n;
+
+        let recvd = &buf[..pos];
+        if recvd.starts_with(b"HTTP/1.1 200") || recvd.starts_with(b"HTTP/1.0 200") {
+            if recvd.ends_with(b"\r\n\r\n") {
+                return Ok(conn);
+            }
+            if pos == buf.len() {
+                return Err(TunnelError::ProxyHeadersTooLong);
+            }
+        // else read more
+        } else if recvd.starts_with(b"HTTP/1.1 407") {
+            return Err(TunnelError::ProxyAuthRequired);
+        } else {
+            return Err(TunnelError::TunnelUnsuccessful);
+        }
+    }
+}

--- a/src/rt/io.rs
+++ b/src/rt/io.rs
@@ -1,0 +1,33 @@
+use std::marker::Unpin;
+use std::pin::Pin;
+use std::task::Poll;
+
+use futures_util::future;
+use futures_util::ready;
+use hyper::rt::{Read, ReadBuf, Write};
+
+pub(crate) async fn read<T>(io: &mut T, buf: &mut [u8]) -> Result<usize, std::io::Error>
+where
+    T: Read + Unpin,
+{
+    future::poll_fn(move |cx| {
+        let mut buf = ReadBuf::new(buf);
+        ready!(Pin::new(&mut *io).poll_read(cx, buf.unfilled()))?;
+        Poll::Ready(Ok(buf.filled().len()))
+    })
+    .await
+}
+
+pub(crate) async fn write_all<T>(io: &mut T, buf: &[u8]) -> Result<(), std::io::Error>
+where
+    T: Write + Unpin,
+{
+    let mut n = 0;
+    future::poll_fn(move |cx| {
+        while n < buf.len() {
+            n += ready!(Pin::new(&mut *io).poll_write(cx, &buf[n..])?);
+        }
+        Poll::Ready(Ok(()))
+    })
+    .await
+}

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -1,5 +1,10 @@
 //! Runtime utilities
 
+#[cfg(feature = "client-legacy")]
+mod io;
+#[cfg(feature = "client-legacy")]
+pub(crate) use self::io::{read, write_all};
+
 #[cfg(feature = "tokio")]
 pub mod tokio;
 

--- a/tests/proxy.rs
+++ b/tests/proxy.rs
@@ -2,7 +2,10 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 use tower_service::Service;
 
-use hyper_util::client::legacy::connect::{proxy::{Socks, Tunnel}, HttpConnector};
+use hyper_util::client::legacy::connect::{
+    proxy::{Socks, Tunnel},
+    HttpConnector,
+};
 
 #[cfg(not(miri))]
 #[tokio::test]
@@ -276,4 +279,3 @@ async fn test_socks_with_domain_works() {
     t1.await.expect("task - client");
     t2.await.expect("task - proxy");
 }
-

--- a/tests/proxy.rs
+++ b/tests/proxy.rs
@@ -1,0 +1,37 @@
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tower_service::Service;
+
+use hyper_util::client::legacy::connect::{proxy::Tunnel, HttpConnector};
+
+#[cfg(not(miri))]
+#[tokio::test]
+async fn test_tunnel_works() {
+    let tcp = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = tcp.local_addr().expect("local_addr");
+
+    let proxy_dst = format!("http://{}", addr).parse().expect("uri");
+    let mut connector = Tunnel::new(proxy_dst, HttpConnector::new());
+    let t1 = tokio::spawn(async move {
+        let _conn = connector
+            .call("https://hyper.rs".parse().unwrap())
+            .await
+            .expect("tunnel");
+    });
+
+    let t2 = tokio::spawn(async move {
+        let (mut io, _) = tcp.accept().await.expect("accept");
+        let mut buf = [0u8; 64];
+        let n = io.read(&mut buf).await.expect("read 1");
+        assert_eq!(
+            &buf[..n],
+            b"CONNECT hyper.rs:443 HTTP/1.1\r\nHost: hyper.rs:443\r\n\r\n"
+        );
+        io.write_all(b"HTTP/1.1 200 OK\r\n\r\n")
+            .await
+            .expect("write 1");
+    });
+
+    t1.await.expect("task 1");
+    t2.await.expect("task 2");
+}

--- a/tests/proxy.rs
+++ b/tests/proxy.rs
@@ -1,8 +1,8 @@
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::TcpListener;
+use tokio::net::{TcpListener, TcpStream};
 use tower_service::Service;
 
-use hyper_util::client::legacy::connect::{proxy::Tunnel, HttpConnector};
+use hyper_util::client::legacy::connect::{proxy::{Socks, Tunnel}, HttpConnector};
 
 #[cfg(not(miri))]
 #[tokio::test]
@@ -35,3 +35,245 @@ async fn test_tunnel_works() {
     t1.await.expect("task 1");
     t2.await.expect("task 2");
 }
+
+#[cfg(not(miri))]
+#[tokio::test]
+async fn test_socks_without_auth_works() {
+    let proxy_tcp = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let proxy_addr = proxy_tcp.local_addr().expect("local_addr");
+    let proxy_dst = format!("http://{}", proxy_addr).parse().expect("uri");
+
+    let target_tcp = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let target_addr = target_tcp.local_addr().expect("local_addr");
+    let target_dst = format!("http://{}", target_addr).parse().expect("uri");
+
+    let mut connector = Socks::new(proxy_dst, HttpConnector::new());
+
+    // Client
+    //
+    // Will use `Tunnel` to establish proxy tunnel.
+    // Will send "Hello World!" to the target and receive "Goodbye!" back.
+    let t1 = tokio::spawn(async move {
+        let conn = connector.call(target_dst).await.expect("tunnel");
+        let mut tcp = conn.into_inner();
+
+        tcp.write_all(b"Hello World!").await.expect("write 1");
+
+        let mut buf = [0u8; 64];
+        let n = tcp.read(&mut buf).await.expect("read 1");
+        assert_eq!(&buf[..n], b"Goodbye!");
+    });
+
+    // Proxy
+    //
+    // Will receive CONNECT request from client.
+    // Will connect to target and send 200 back to client.
+    // Will blindly tunnel between client and target.
+    let t2 = tokio::spawn(async move {
+        let (mut to_client, _) = proxy_tcp.accept().await.expect("accept");
+        let mut buf = [0u8; 513];
+
+        // negotiation req/res
+        let n = to_client.read(&mut buf).await.expect("read 1");
+        assert_eq!(&buf[..n], [0x05, 0x01, 0x00]);
+
+        to_client.write_all(&[0x05, 0x00]).await.expect("write 1");
+
+        // command req/rs
+        let [p1, p2] = target_addr.port().to_be_bytes();
+        let [ip1, ip2, ip3, ip4] = [0x7f, 0x00, 0x00, 0x01];
+        let message = [0x05, 0x01, 0x00, 0x01, ip1, ip2, ip3, ip4, p1, p2];
+        let n = to_client.read(&mut buf).await.expect("read 2");
+        assert_eq!(&buf[..n], message);
+
+        let mut to_target = TcpStream::connect(target_addr).await.expect("connect");
+
+        let message = [0x05, 0x00, 0x00, 0x01, ip1, ip2, ip3, ip4, p1, p2];
+        to_client.write_all(&message).await.expect("write 2");
+
+        let (from_client, from_target) =
+            tokio::io::copy_bidirectional(&mut to_client, &mut to_target)
+                .await
+                .expect("proxy");
+
+        assert_eq!(from_client, 12);
+        assert_eq!(from_target, 8)
+    });
+
+    // Target server
+    //
+    // Will accept connection from proxy server
+    // Will receive "Hello World!" from the client and return "Goodbye!"
+    let t3 = tokio::spawn(async move {
+        let (mut io, _) = target_tcp.accept().await.expect("accept");
+        let mut buf = [0u8; 64];
+
+        let n = io.read(&mut buf).await.expect("read 1");
+        assert_eq!(&buf[..n], b"Hello World!");
+
+        io.write_all(b"Goodbye!").await.expect("write 1");
+    });
+
+    t1.await.expect("task - client");
+    t2.await.expect("task - proxy");
+    t3.await.expect("task - target");
+}
+
+#[cfg(not(miri))]
+#[tokio::test]
+async fn test_socks_with_auth_works() {
+    let proxy_tcp = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let proxy_addr = proxy_tcp.local_addr().expect("local_addr");
+    let proxy_dst = format!("http://{}", proxy_addr).parse().expect("uri");
+
+    let target_tcp = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let target_addr = target_tcp.local_addr().expect("local_addr");
+    let target_dst = format!("http://{}", target_addr).parse().expect("uri");
+
+    let mut connector =
+        Socks::new(proxy_dst, HttpConnector::new()).with_auth("user".into(), "pass".into());
+
+    // Client
+    //
+    // Will use `Tunnel` to establish proxy tunnel.
+    // Will send "Hello World!" to the target and receive "Goodbye!" back.
+    let t1 = tokio::spawn(async move {
+        let conn = connector.call(target_dst).await.expect("tunnel");
+        let mut tcp = conn.into_inner();
+
+        tcp.write_all(b"Hello World!").await.expect("write 1");
+
+        let mut buf = [0u8; 64];
+        let n = tcp.read(&mut buf).await.expect("read 1");
+        assert_eq!(&buf[..n], b"Goodbye!");
+    });
+
+    // Proxy
+    //
+    // Will receive CONNECT request from client.
+    // Will connect to target and send 200 back to client.
+    // Will blindly tunnel between client and target.
+    let t2 = tokio::spawn(async move {
+        let (mut to_client, _) = proxy_tcp.accept().await.expect("accept");
+        let mut buf = [0u8; 513];
+
+        // negotiation req/res
+        let n = to_client.read(&mut buf).await.expect("read 1");
+        assert_eq!(&buf[..n], [0x05, 0x01, 0x02]);
+
+        to_client.write_all(&[0x05, 0x02]).await.expect("write 1");
+
+        // auth req/res
+        let n = to_client.read(&mut buf).await.expect("read 2");
+        let [u1, u2, u3, u4] = b"user";
+        let [p1, p2, p3, p4] = b"pass";
+        let message = [0x01, 0x04, *u1, *u2, *u3, *u4, 0x04, *p1, *p2, *p3, *p4];
+        assert_eq!(&buf[..n], message);
+
+        to_client.write_all(&[0x01, 0x00]).await.expect("write 2");
+
+        // command req/res
+        let n = to_client.read(&mut buf).await.expect("read 3");
+        let [p1, p2] = target_addr.port().to_be_bytes();
+        let [ip1, ip2, ip3, ip4] = [0x7f, 0x00, 0x00, 0x01];
+        let message = [0x05, 0x01, 0x00, 0x01, ip1, ip2, ip3, ip4, p1, p2];
+        assert_eq!(&buf[..n], message);
+
+        let mut to_target = TcpStream::connect(target_addr).await.expect("connect");
+
+        let message = [0x05, 0x00, 0x00, 0x01, ip1, ip2, ip3, ip4, p1, p2];
+        to_client.write_all(&message).await.expect("write 3");
+
+        let (from_client, from_target) =
+            tokio::io::copy_bidirectional(&mut to_client, &mut to_target)
+                .await
+                .expect("proxy");
+
+        assert_eq!(from_client, 12);
+        assert_eq!(from_target, 8)
+    });
+
+    // Target server
+    //
+    // Will accept connection from proxy server
+    // Will receive "Hello World!" from the client and return "Goodbye!"
+    let t3 = tokio::spawn(async move {
+        let (mut io, _) = target_tcp.accept().await.expect("accept");
+        let mut buf = [0u8; 64];
+
+        let n = io.read(&mut buf).await.expect("read 1");
+        assert_eq!(&buf[..n], b"Hello World!");
+
+        io.write_all(b"Goodbye!").await.expect("write 1");
+    });
+
+    t1.await.expect("task - client");
+    t2.await.expect("task - proxy");
+    t3.await.expect("task - target");
+}
+
+#[cfg(not(miri))]
+#[tokio::test]
+async fn test_socks_with_domain_works() {
+    let proxy_tcp = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let proxy_addr = proxy_tcp.local_addr().expect("local_addr");
+    let proxy_addr = format!("http://{}", proxy_addr).parse().expect("uri");
+
+    let mut connector =
+        Socks::new(proxy_addr, HttpConnector::new()).with_auth("user".into(), "pass".into());
+
+    // Client
+    //
+    // Will use `Tunnel` to establish proxy tunnel.
+    // Will send "Hello World!" to the target and receive "Goodbye!" back.
+    let t1 = tokio::spawn(async move {
+        let _conn = connector
+            .call("https://hyper.rs:443".try_into().unwrap())
+            .await
+            .expect("tunnel");
+    });
+
+    // Proxy
+    //
+    // Will receive CONNECT request from client.
+    // Will connect to target and send 200 back to client.
+    // Will blindly tunnel between client and target.
+    let t2 = tokio::spawn(async move {
+        let (mut to_client, _) = proxy_tcp.accept().await.expect("accept");
+        let mut buf = [0u8; 513];
+
+        // negotiation req/res
+        let n = to_client.read(&mut buf).await.expect("read 1");
+        assert_eq!(&buf[..n], [0x05, 0x01, 0x02]);
+
+        to_client.write_all(&[0x05, 0x02]).await.expect("write 1");
+
+        // auth req/res
+        let n = to_client.read(&mut buf).await.expect("read 2");
+        let [u1, u2, u3, u4] = b"user";
+        let [p1, p2, p3, p4] = b"pass";
+        let message = [0x01, 0x04, *u1, *u2, *u3, *u4, 0x04, *p1, *p2, *p3, *p4];
+        assert_eq!(&buf[..n], message);
+
+        to_client.write_all(&[0x01, 0x00]).await.expect("write 2");
+
+        // command req/res
+        let n = to_client.read(&mut buf).await.expect("read 3");
+
+        let host = "hyper.rs";
+        let port: u16 = 443;
+        let mut message = vec![0x05, 0x01, 0x00, 0x03, host.len() as u8];
+        message.extend(host.bytes());
+        message.extend(port.to_be_bytes());
+        assert_eq!(&buf[..n], message);
+
+        let mut message = vec![0x05, 0x00, 0x00, 0x03, host.len() as u8];
+        message.extend(host.bytes());
+        message.extend(port.to_be_bytes());
+        to_client.write_all(&message).await.expect("write 3");
+    });
+
+    t1.await.expect("task - client");
+    t2.await.expect("task - proxy");
+}
+


### PR DESCRIPTION
cc hyperium/hyper#3851
builds atop hyperium/hyper-util#140

Adds `Socks` connector. Didn't pull existing crates as it's a simple enough protocol. Behaviour is there, clean up still necessary for error handling, etc...

`connect()` function will be refactored to enum-based state machine to make optimistic sending of messages cleaner. Optimistic sending isn't in the [RFC](https://datatracker.ietf.org/doc/html/rfc1928) but most existing server implementations can handle it from my testing. Worth adding for RTT reduction; will document to make clear it might not work.



