### PR TITLE
chore: bump msrv to 1.65

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -60,7 +60,7 @@ jobs:
     needs: [style]
     strategy:
       matrix:
-        rust: [ 1.63 ] # keep in sync with 'rust-version' in Cargo.toml
+        rust: [ 1.65 ] # keep in sync with 'rust-version' in Cargo.toml
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ authors = ["Sean McArthur <sean@seanmonstar.com>"]
 keywords = ["http", "hyper", "hyperium"]
 categories = ["network-programming", "web-programming::http-client", "web-programming::http-server"]
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.65"
 
 [package.metadata.docs.rs]
 features = ["full"]


### PR DESCRIPTION
this crate can no longer be built on 1.63 due to a dependency increasing its own msrv. this commit bumps hyper-util's minimum rust version.

```
Run cargo check --features full
    Updating crates.io index
 Downloading crates ...
  Downloaded atomic-waker v1.1.2
  Downloaded autocfg v1.4.0
  Downloaded equivalent v1.0.2
  Downloaded fnv v1.0.7
  Downloaded futures-core v0.3.31
  Downloaded futures-task v0.3.31
  Downloaded futures-util v0.3.31
  Downloaded itoa v1.0.15
  Downloaded indexmap v2.8.0
  Downloaded proc-macro2 v1.0.94
  Downloaded pin-project-lite v0.2.16
  Downloaded quote v1.0.40
  Downloaded socket2 v0.5.8
  Downloaded tokio-macros v2.3.0
  Downloaded signal-hook-registry v1.4.2
  Downloaded unicode-ident v1.0.18
  Downloaded try-lock v0.2.5
  Downloaded want v0.3.1
  Downloaded tracing-core v0.1.33
  Downloaded slab v0.4.9
  Downloaded tracing v0.1.41
  Downloaded tower-service v0.3.3
  Downloaded syn v2.0.100
  Downloaded smallvec v1.14.0
  Downloaded pin-utils v0.1.0
  Downloaded tokio v1.38.1
  Downloaded libc v0.2.171
  Downloaded once_cell v1.21.1
  Downloaded mio v0.8.11
  Downloaded hyper v1.6.0
  Downloaded httpdate v1.0.3
  Downloaded httparse v1.10.1
  Downloaded http v1.3.1
  Downloaded hashbrown v0.15.0
  Downloaded h2 v0.4.8
  Downloaded futures-sink v0.3.31
  Downloaded futures-channel v0.3.31
  Downloaded bytes v1.10.1
  Downloaded http-body v1.0.1
  Downloaded tokio-util v0.7.11
error: package `once_cell v1.21.1` cannot be built because it requires rustc 1.65 or newer, while the currently active rustc version is 1.63.0
Error: Process completed with exit code 101.
```