### PR TITLE
fix(server): Enforce `serve_connection` result usage

### DIFF
--- a/src/server/conn/auto/mod.rs
+++ b/src/server/conn/auto/mod.rs
@@ -495,7 +495,8 @@ where
 }
 
 pin_project! {
-    /// An future binding a connection with a Service with Upgrade support.
+    /// An upgradable [`Connection`], returned by
+    /// [`Builder::serve_upgradable_connection`](struct.Builder.html#method.serve_connection_with_upgrades).
     ///
     /// To drive HTTP on this connection this future **must be polled**, typically with
     /// `.await`. If it isn't polled, no progress will be made on this connection.

--- a/src/server/conn/auto/mod.rs
+++ b/src/server/conn/auto/mod.rs
@@ -156,6 +156,7 @@ impl<E> Builder<E> {
     }
 
     /// Bind a connection together with a [`Service`].
+    #[must_use]
     pub fn serve_connection<I, S, B>(&self, io: I, service: S) -> Connection<'_, I, S, E>
     where
         S: Service<Request<Incoming>, Response = Response<B>>,
@@ -199,6 +200,7 @@ impl<E> Builder<E> {
     /// instead. See the documentation of the latter to understand why.
     ///
     /// [`hyper_util::server::conn::auto::upgrade::downcast`]: crate::server::conn::auto::upgrade::downcast
+    #[must_use]
     pub fn serve_connection_with_upgrades<I, S, B>(
         &self,
         io: I,

--- a/src/server/conn/auto/mod.rs
+++ b/src/server/conn/auto/mod.rs
@@ -156,7 +156,6 @@ impl<E> Builder<E> {
     }
 
     /// Bind a connection together with a [`Service`].
-    #[must_use]
     pub fn serve_connection<I, S, B>(&self, io: I, service: S) -> Connection<'_, I, S, E>
     where
         S: Service<Request<Incoming>, Response = Response<B>>,
@@ -200,7 +199,6 @@ impl<E> Builder<E> {
     /// instead. See the documentation of the latter to understand why.
     ///
     /// [`hyper_util::server::conn::auto::upgrade::downcast`]: crate::server::conn::auto::upgrade::downcast
-    #[must_use]
     pub fn serve_connection_with_upgrades<I, S, B>(
         &self,
         io: I,
@@ -320,7 +318,12 @@ where
 }
 
 pin_project! {
-    /// Connection future.
+    /// A [`Future`](core::future::Future) representing an HTTP/1 connection, returned from
+    /// [`Builder::serve_connection`](struct.Builder.html#method.serve_connection).
+    ///
+    /// To drive HTTP on this connection this future **must be polled**, typically with
+    /// `.await`. If it isn't polled, no progress will be made on this connection.
+    #[must_use = "futures do nothing unless polled"]
     pub struct Connection<'a, I, S, E>
     where
         S: HttpService<Incoming>,
@@ -492,7 +495,11 @@ where
 }
 
 pin_project! {
-    /// Connection future.
+    /// An future binding a connection with a Service with Upgrade support.
+    ///
+    /// To drive HTTP on this connection this future **must be polled**, typically with
+    /// `.await`. If it isn't polled, no progress will be made on this connection.
+    #[must_use = "futures do nothing unless polled"]
     pub struct UpgradeableConnection<'a, I, S, E>
     where
         S: HttpService<Incoming>,


### PR DESCRIPTION
- Mark `serve_connection` and `serve_connection_with_upgrades` as `must_use` to prevent ignored results.  
- Mark `serve_connection_with_upgrades` as `must_use` for consistency.  
- Helps avoid silent issues when forgetting to `.await` the connection.  

Not a major issue, but spent 15 minutes debugging due to a missing `.await`.