### PR TITLE
fix(tracing): revert #134 - tracing span removal in legacy DNS `GaiResolver`

### DIFF
--- a/src/client/legacy/connect/dns.rs
+++ b/src/client/legacy/connect/dns.rs
@@ -30,7 +30,6 @@ use std::{fmt, io, vec};
 
 use tokio::task::JoinHandle;
 use tower_service::Service;
-use tracing::debug_span;
 
 pub(super) use self::sealed::Resolve;
 
@@ -117,9 +116,7 @@ impl Service<Name> for GaiResolver {
     }
 
     fn call(&mut self, name: Name) -> Self::Future {
-        let span = debug_span!("resolve", host = %name.host);
         let blocking = tokio::task::spawn_blocking(move || {
-            let _enter = span.enter();
             (&*name.host, 0)
                 .to_socket_addrs()
                 .map(|i| SocketAddrs { iter: i })


### PR DESCRIPTION
`tracing` has an unresolved bug when attempting to fetch a span that _should_ exist. Tracking: https://github.com/tokio-rs/tracing/issues/3223#issuecomment-2771038993

#134 introduces this bug. `hyper` contributors aren't at fault — this is a `tracing` issue.

As a result, crates that depend on `hyper`'s legacy client (e.g. `reqwest`) will immediately panic when a request is sent under specific circumstances configured by `tracing` spans. (The tracked comment shows a pseudocode example). This slightly more accurate `tracing` span is not worth the panics. 

In theory, this PR can be reverted once `tracing` resolves this issue, but its up to the maintainers whether or not it should be prioritized.

