### PR TITLE
feat(server): implement default for server auto connection builder

### DIFF
--- a/src/server/conn/auto/mod.rs
+++ b/src/server/conn/auto/mod.rs
@@ -66,6 +66,12 @@ pub struct Builder<E> {
     _executor: E,
 }
 
+impl<E: Default> Default for Builder<E> {
+    fn default() -> Self {
+        Self::new(E::default())
+    }
+}
+
 impl<E> Builder<E> {
     /// Create a new auto connection builder.
     ///


### PR DESCRIPTION
This allows to use default trait to create a builder when the used executor implements default.