### PR TITLE
feat(server): add method to get number of watching connection

### DIFF
--- a/src/server/graceful.rs
+++ b/src/server/graceful.rs
@@ -68,6 +68,11 @@ impl GracefulShutdown {
         // and then wait for all of them to complete
         tx.closed().await;
     }
+
+    /// Returns the number of the watching connections.
+    pub fn count(&self) -> usize {
+        self.tx.receiver_count()
+    }
 }
 
 impl Debug for GracefulShutdown {


### PR DESCRIPTION
This adds a method to get the number of the watching connections, which is useful mainly for the debug purpose.