### PR TITLE
docs(client): Include .pool_timer() in the Client builder example

### DIFF
--- a/src/client/legacy/client.rs
+++ b/src/client/legacy/client.rs
@@ -122,9 +122,10 @@ impl Client<(), ()> {
     /// # fn run () {
     /// use std::time::Duration;
     /// use hyper_util::client::legacy::Client;
-    /// use hyper_util::rt::TokioExecutor;
+    /// use hyper_util::rt::{TokioExecutor, TokioTimer};
     ///
     /// let client = Client::builder(TokioExecutor::new())
+    ///     .pool_timer(TokioTimer::new())
     ///     .pool_idle_timeout(Duration::from_secs(30))
     ///     .http2_only(true)
     ///     .build_http();


### PR DESCRIPTION
The example (/doctest) uses a pool idle timeout, which according to the docs doesn't actually do anything without a pool timer.

Including a timer makes this example less misleading.