### PR TITLE
Add Hermit support

### DIFF
--- a/src/client/legacy/connect/http.rs
+++ b/src/client/legacy/connect/http.rs
@@ -911,13 +911,16 @@ fn connect(
     )
     .map_err(ConnectError::m("tcp bind local error"))?;
 
-    #[cfg(unix)]
+    #[cfg(any(unix, target_os = "hermit"))]
     let socket = unsafe {
         // Safety: `from_raw_fd` is only safe to call if ownership of the raw
         // file descriptor is transferred. Since we call `into_raw_fd` on the
         // socket2 socket, it gives up ownership of the fd and will not close
         // it, so this is safe.
+        #[cfg(unix)]
         use std::os::unix::io::{FromRawFd, IntoRawFd};
+        #[cfg(target_os = "hermit")]
+        use std::os::hermit::io::{FromRawFd, IntoRawFd};
         TcpSocket::from_raw_fd(socket.into_raw_fd())
     };
     #[cfg(windows)]


### PR DESCRIPTION
This PR adds support for the Hermit OS. For networking, we try to adhere to POSIX, so we should be similar to Unix.