### PR TITLE
chore(test): make proxy test robust wrt IPv4/v6

### DIFF
--- a/tests/proxy.rs
+++ b/tests/proxy.rs
@@ -327,9 +327,10 @@ async fn test_socks_v5_with_locally_resolved_domain_works() {
 
         // command req/res
         let n = to_client.read(&mut buf).await.expect("read 3");
-        let message = [0x05, 0x01, 0x00, 0x01];
-        assert_eq!(&buf[..4], message);
-        assert_eq!(n, 4 + 4 + 2);
+        let message = [0x05, 0x01, 0x00];
+        assert_eq!(&buf[..3], message);
+        assert!(buf[3] == 0x01 || buf[3] == 0x04); // IPv4 or IPv6
+        assert_eq!(n, 4 + 4 * (buf[3] as usize) + 2);
 
         let message = vec![0x05, 0x00, 0x00, 0x01, 0, 0, 0, 0, 0, 0];
         to_client.write_all(&message).await.expect("write 3");


### PR DESCRIPTION
this test fails if hyper.rs resolves to an IPv6 address in the test env otherwise:

```
running 1 test

thread 'test_socks_v5_with_locally_resolved_domain_works' panicked at tests/proxy.rs:331:9:
assertion `left == right` failed
  left: [5, 1, 0, 4]
 right: [5, 1, 0, 1]
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

thread 'test_socks_v5_with_locally_resolved_domain_works' panicked at tests/proxy.rs:301:14:
tunnel: Io(Custom { kind: UnexpectedEof, error: "unexpected eof" })

thread 'test_socks_v5_with_locally_resolved_domain_works' panicked at tests/proxy.rs:338:14:
task - client: JoinError::Panic(Id(1), "tunnel: Io(Custom { kind: UnexpectedEof, error: \"unexpected eof\" })", ...)
test test_socks_v5_with_locally_resolved_domain_works ... FAILED

failures:

failures:
    test_socks_v5_with_locally_resolved_domain_works

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 6 filtered out; finished in 0.01s
```

the full message returned by the test proxy:

`[5, 1, 0, 4, 38, 6, 71, 0, 48, 55, 0, 0, 0, 0, 0, 0, 104, 21, 12, 232, 1, 187,0, ..]` where `[4..]` of that in hex is `['0x26', '0x6', '0x47', '0x0', '0x30', '0x37', '0x0', '0x0', '0x0', '0x0', '0x0', '0x0', '0x68', '0x15', '0xc', '0xe8', '0x1', '0xbb']` which corresponds to

```
$ host hyper.rs
...
hyper.rs has IPv6 address 2606:4700:3037::6815:ce8
...
```

