### PR TITLE
Update to `windows-registry` 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ pnet_datalink = "0.35.0"
 system-configuration = { version = "0.6.1", optional = true }
 
 [target.'cfg(windows)'.dependencies]
-windows-registry = { version = "0.4", optional = true }
+windows-registry = { version = "0.5", optional = true }
 
 [features]
 default = []


### PR DESCRIPTION
This version of [windows-registry](https://crates.io/crates/windows-registry) is [largely the same](https://github.com/microsoft/windows-rs/releases/tag/64) but greatly reduces your dependencies as it uses the tiny [windows-link](https://crates.io/crates/windows-link) crate for linking Windows imports rather than the older [windows-targets](https://crates.io/crates/windows-targets) crate that pulls down a bunch of large import libs. 