### PR TITLE
style(client): Fix some clippy lints

### DIFF
--- a/src/client/legacy/connect/http.rs
+++ b/src/client/legacy/connect/http.rs
@@ -489,14 +489,14 @@ fn get_host_port<'u>(config: &Config, dst: &'u Uri) -> Result<(&'u str, u16), Co
     if config.enforce_http {
         if dst.scheme() != Some(&Scheme::HTTP) {
             return Err(ConnectError {
-                msg: INVALID_NOT_HTTP.into(),
+                msg: INVALID_NOT_HTTP,
                 addr: None,
                 cause: None,
             });
         }
     } else if dst.scheme().is_none() {
         return Err(ConnectError {
-            msg: INVALID_MISSING_SCHEME.into(),
+            msg: INVALID_MISSING_SCHEME,
             addr: None,
             cause: None,
         });
@@ -506,7 +506,7 @@ fn get_host_port<'u>(config: &Config, dst: &'u Uri) -> Result<(&'u str, u16), Co
         Some(s) => s,
         None => {
             return Err(ConnectError {
-                msg: INVALID_MISSING_HOST.into(),
+                msg: INVALID_MISSING_HOST,
                 addr: None,
                 cause: None,
             })
@@ -693,7 +693,7 @@ impl fmt::Debug for ConnectError {
 
 impl fmt::Display for ConnectError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.msg)
+        f.write_str(self.msg)
     }
 }
 


### PR DESCRIPTION
This pull request simplifies error handling in `src/client/legacy/connect/http.rs` by removing unnecessary `.into()` calls when assigning error messages and updating the `fmt::Display` implementation of `ConnectError` to directly use the message string. These changes improve code clarity and reduce redundant operations.