### PR TITLE
fix(client): prefer resolver order always

### DIFF
--- a/src/client/legacy/connect/dns.rs
+++ b/src/client/legacy/connect/dns.rs
@@ -214,12 +214,19 @@ impl SocketAddrs {
         local_addr_ipv6: Option<Ipv6Addr>,
     ) -> (SocketAddrs, SocketAddrs) {
         match (local_addr_ipv4, local_addr_ipv6) {
-            // Filter out based on what the local addr can use
             (Some(_), None) => (self.filter(SocketAddr::is_ipv4), SocketAddrs::new(vec![])),
             (None, Some(_)) => (self.filter(SocketAddr::is_ipv6), SocketAddrs::new(vec![])),
             _ => {
-                // Happy Eyeballs says we always give a preference to v6 if available
-                let (preferred, fallback) = self.iter.partition::<Vec<_>, _>(SocketAddr::is_ipv6);
+                let preferring_v6 = self
+                    .iter
+                    .as_slice()
+                    .first()
+                    .map(SocketAddr::is_ipv6)
+                    .unwrap_or(false);
+
+                let (preferred, fallback) = self
+                    .iter
+                    .partition::<Vec<_>, _>(|addr| addr.is_ipv6() == preferring_v6);
 
                 (SocketAddrs::new(preferred), SocketAddrs::new(fallback))
             }
@@ -300,13 +307,12 @@ mod tests {
         let v4_addr = (ip_v4, 80).into();
         let v6_addr = (ip_v6, 80).into();
 
-        // Even if ipv4 started first, prefer ipv6
         let (mut preferred, mut fallback) = SocketAddrs {
             iter: vec![v4_addr, v6_addr].into_iter(),
         }
         .split_by_preference(None, None);
-        assert!(preferred.next().unwrap().is_ipv6());
-        assert!(fallback.next().unwrap().is_ipv4());
+        assert!(preferred.next().unwrap().is_ipv4());
+        assert!(fallback.next().unwrap().is_ipv6());
 
         let (mut preferred, mut fallback) = SocketAddrs {
             iter: vec![v6_addr, v4_addr].into_iter(),
@@ -319,8 +325,8 @@ mod tests {
             iter: vec![v4_addr, v6_addr].into_iter(),
         }
         .split_by_preference(Some(ip_v4), Some(ip_v6));
-        assert!(preferred.next().unwrap().is_ipv6());
-        assert!(fallback.next().unwrap().is_ipv4());
+        assert!(preferred.next().unwrap().is_ipv4());
+        assert!(fallback.next().unwrap().is_ipv6());
 
         let (mut preferred, mut fallback) = SocketAddrs {
             iter: vec![v6_addr, v4_addr].into_iter(),


### PR DESCRIPTION
This was changed in #194, but that change seems to be wrong. The resolver is allowed to express it's priority through the ordering.

See https://datatracker.ietf.org/doc/html/rfc6555#section-6 and https://github.com/curl/curl/issues/16718.

Closes https://github.com/hyperium/hyper/issues/3900