### PR TITLE
feat(builder): support header case methods

### DIFF
--- a/src/server/conn/auto/mod.rs
+++ b/src/server/conn/auto/mod.rs
@@ -186,6 +186,30 @@ impl<E> Builder<E> {
         self
     }
 
+    /// Set whether HTTP/1 connections will preserve the original case of header names.
+    ///
+    /// This setting only affects HTTP/1 connections. HTTP/2 connections are
+    /// not affected by this setting.
+    ///
+    /// Default is false.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hyper_util::{
+    ///     rt::TokioExecutor,
+    ///     server::conn::auto,
+    /// };
+    ///
+    /// auto::Builder::new(TokioExecutor::new())
+    ///     .preserve_header_case(true);
+    /// ```
+    #[cfg(feature = "http1")]
+    pub fn preserve_header_case(mut self, enabled: bool) -> Self {
+        self.http1.preserve_header_case(enabled);
+        self
+    }
+
     /// Bind a connection together with a [`Service`].
     pub fn serve_connection<I, S, B>(&self, io: I, service: S) -> Connection<'_, I, S, E>
     where
@@ -1146,6 +1170,18 @@ mod tests {
         // Can be combined with other configuration
         auto::Builder::new(TokioExecutor::new())
             .title_case_headers(true)
+            .http1_only();
+    }
+
+    #[test]
+    #[cfg(feature = "http1")]
+    fn preserve_header_case_configuration() {
+        // Test preserve_header_case can be set on the main builder
+        auto::Builder::new(TokioExecutor::new()).preserve_header_case(true);
+
+        // Can be combined with other configuration
+        auto::Builder::new(TokioExecutor::new())
+            .preserve_header_case(true)
             .http1_only();
     }
 


### PR DESCRIPTION
Hey, it’d be great to have the ability to use `title_case_headers` and `preserve_header_case` with `auto::Builder`. Could you take a look at this PR?