### PR TITLE
feat(client): re-export tower_service::Service to reduce unnecessary dependency exposure when implementing hyper-util traits

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,4 +15,7 @@ pub mod server;
 #[cfg(any(feature = "service", feature = "client-legacy"))]
 pub mod service;
 
+#[cfg(any(feature = "service", feature = "client"))]
+pub use tower_service::Service;
+
 mod error;


### PR DESCRIPTION
re-export tower_service::Service to reduce unnecessary dependency exposure when implementing hyper-util traits