### PR TITLE
chore(test): remove some miri exception config

### DIFF
--- a/src/client/legacy/connect/capture.rs
+++ b/src/client/legacy/connect/capture.rs
@@ -119,7 +119,7 @@ impl CaptureConnection {
     }
 }
 
-#[cfg(all(test, not(miri)))]
+#[cfg(test)]
 mod test {
     use super::*;
 

--- a/src/client/legacy/connect/http.rs
+++ b/src/client/legacy/connect/http.rs
@@ -509,7 +509,7 @@ fn get_host_port<'u>(config: &Config, dst: &'u Uri) -> Result<(&'u str, u16), Co
                 msg: INVALID_MISSING_HOST,
                 addr: None,
                 cause: None,
-            })
+            });
         }
     };
     let port = match dst.port() {
@@ -1038,7 +1038,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg_attr(miri, ignore)]
     async fn test_errors_enforce_http() {
         let dst = "https://example.domain/foo/bar?baz".parse().unwrap();
         let connector = HttpConnector::new();
@@ -1082,7 +1081,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg_attr(miri, ignore)]
     async fn test_errors_missing_scheme() {
         let dst = "example.domain".parse().unwrap();
         let mut connector = HttpConnector::new();

--- a/src/client/legacy/pool.rs
+++ b/src/client/legacy/pool.rs
@@ -826,7 +826,7 @@ impl<T> WeakOpt<T> {
     }
 }
 
-#[cfg(all(test, not(miri)))]
+#[cfg(test)]
 mod tests {
     use std::fmt::Debug;
     use std::future::Future;

--- a/src/rt/tokio.rs
+++ b/src/rt/tokio.rs
@@ -326,7 +326,6 @@ mod tests {
     use hyper::rt::Executor;
     use tokio::sync::oneshot;
 
-    #[cfg(not(miri))]
     #[tokio::test]
     async fn simple_execute() -> Result<(), Box<dyn std::error::Error>> {
         let (tx, rx) = oneshot::channel();

--- a/tests/legacy_client.rs
+++ b/tests/legacy_client.rs
@@ -354,7 +354,6 @@ async fn socket_disconnect_closes_idle_conn() {
     future::select(t, close).await;
 }
 
-#[cfg(not(miri))]
 #[test]
 fn connect_call_is_lazy() {
     // We especially don't want connects() triggered if there's
@@ -1328,7 +1327,6 @@ impl tower_service::Service<hyper::Uri> for MockConnector {
 // Test for connection error propagation with PR #184.
 // Simulates a connection failure by setting failed=true and returning a custom io::Error.
 // Verifies the error propagates through hyper’s client as a hyper::Error(Io, ...).
-#[cfg(not(miri))]
 #[tokio::test]
 async fn test_connection_error_propagation_pr184() {
     // Define the error message for the simulated connection failure.
@@ -1386,7 +1384,6 @@ async fn test_connection_error_propagation_pr184() {
 // Simulates a connection that returns EOF immediately, causing hyper’s HTTP/1.1 parser
 // to fail with IncompleteMessage due to no response data.
 // Uses MockConnector with conn_error=None to keep failed=false, ensuring EOF behavior.
-#[cfg(not(miri))]
 #[tokio::test]
 async fn test_incomplete_message_error_pr184() {
     // Create an empty IoBuilder to simulate a connection with no data.
@@ -1446,7 +1443,6 @@ async fn test_incomplete_message_error_pr184() {
 // Test for a successful HTTP/1.1 connection using a mock connector.
 // Simulates a server that accepts a request and responds with a 200 OK.
 // Verifies the client correctly sends the request and receives the response.
-#[cfg(not(miri))]
 #[tokio::test]
 async fn test_successful_connection() {
     // Define the expected server response: a valid HTTP/1.1 200 OK with no body.


### PR DESCRIPTION
Some tests seem to be able to be run with miri.