### PR TITLE
fix(client): allow absolute-form if is_proxied is set even on HTTPS

### DIFF
--- a/src/client/legacy/client.rs
+++ b/src/client/legacy/client.rs
@@ -909,12 +909,6 @@ fn absolute_form(uri: &mut Uri) {
         uri.authority().is_some(),
         "absolute_form needs an authority"
     );
-    // If the URI is to HTTPS, and the connector claimed to be a proxy,
-    // then it *should* have tunneled, and so we don't want to send
-    // absolute-form in that case.
-    if uri.scheme() == Some(&Scheme::HTTPS) {
-        origin_form(uri);
-    }
 }
 
 fn authority_form(uri: &mut Uri) {


### PR DESCRIPTION
After looking at this again, this seems wrong. The _only_ purpose for setting `is_proxied` is to signal that an absolute-form URI should be sent. A tunneling proxy should not set that it `is_proxied`.

cc @devsnek