### PR TITLE
refactor(pool): use `sleep` instead of `sleep_until`

### DIFF
--- a/src/client/legacy/pool.rs
+++ b/src/client/legacy/pool.rs
@@ -785,7 +785,7 @@ impl<T: Poolable + 'static, K: Key> IdleTask<T, K> {
     async fn run(self) {
         use futures_util::future;
 
-        let mut sleep = self.timer.sleep_until(Instant::now() + self.duration);
+        let mut sleep = self.timer.sleep(self.duration);
         let mut on_pool_drop = self.pool_drop_notifier;
         loop {
             match future::select(&mut on_pool_drop, &mut sleep).await {
@@ -801,8 +801,7 @@ impl<T: Poolable + 'static, K: Key> IdleTask<T, K> {
                         }
                     }
 
-                    let deadline = Instant::now() + self.duration;
-                    self.timer.reset(&mut sleep, deadline);
+                    sleep = self.timer.sleep(self.duration);
                 }
             }
         }


### PR DESCRIPTION
This PR refactors the usage of `Timer::sleep_until` with `Timer::sleep`.

`sleep_until` is a convenient method that is logically equivalent with `sleep`, but requires the use of `std::time::Instant`.  This have some effect when downstream users rely on non-std `Instant`.