### PR TITLE
Event Handler added to legacy Client.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ socket2 = { version = ">=0.5.9, <0.7", optional = true, features = ["all"] }
 tracing = { version = "0.1", default-features = false, features = ["std"], optional = true }
 tokio = { version = "1", optional = true, default-features = false  }
 tower-service = { version = "0.3", optional = true }
+scopeguard = "1.2.0"
 
 [dev-dependencies]
 hyper = { version = "1.4.0", features = ["full"] }

--- a/src/client/legacy/client.rs
+++ b/src/client/legacy/client.rs
@@ -1486,6 +1486,21 @@ impl Builder {
         self
     }
 
+    /// Sets the maximum number of HTTP2 concurrent streams.
+    ///
+    /// See the documentation of [`h2::client::Builder::max_concurrent_streams`] for more
+    /// details.
+    ///
+    /// The default value is determined by the `h2` crate.
+    ///
+    /// [`h2::client::Builder::max_concurrent_streams`]: https://docs.rs/h2/client/struct.Builder.html#method.max_concurrent_streams
+    #[cfg(feature = "http2")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
+    pub fn http2_max_concurrent_streams(&mut self, max: u32) -> &mut Self {
+        self.h2_builder.max_concurrent_streams(max);
+        self
+    }
+
     /// Sets the maximum number of HTTP2 concurrent locally reset streams.
     ///
     /// See the documentation of [`h2::client::Builder::max_concurrent_reset_streams`] for more

--- a/src/client/legacy/mod.rs
+++ b/src/client/legacy/mod.rs
@@ -1,7 +1,7 @@
 #[cfg(any(feature = "http1", feature = "http2"))]
 mod client;
 #[cfg(any(feature = "http1", feature = "http2"))]
-pub use client::{Builder, Client, Error, ResponseFuture};
+pub use client::{Builder, Client, Error, PoolKey, ResponseFuture};
 
 pub mod connect;
 #[doc(hidden)]


### PR DESCRIPTION
This merge request introduces an Event Handler to the legacy client, an extension currently used in the [Orion proxy](https://github.com/kmesh-net/orion).

The event handler, when enabled, allows the application to receive notifications about specific events occurring in the connection pool — such as the creation of a new connection, the closing of an idle connection, and more.

Specifically, this MR:
- Adds the pool event notification mechanism to the legacy client.
- Adds the http2_max_concurrent_streams setter.