### PR TITLE
Move `tokio/net` feature to `client-legacy`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,9 +74,9 @@ full = [
     "tracing",
 ]
 
-client = ["hyper/client", "tokio/net", "dep:tracing", "dep:futures-channel", "dep:tower-service"]
-client-legacy = ["client", "dep:socket2", "tokio/sync", "dep:libc", "dep:futures-util"]
-client-pool = ["client", "dep:futures-util", "dep:tower-layer"]
+client = ["hyper/client", "dep:tracing", "dep:futures-channel", "dep:tower-service"]
+client-legacy = ["client", "tokio/net", "dep:socket2", "tokio/sync", "dep:libc", "dep:futures-util"]
+client-pool = ["client", "dep:futures-util", "dep:tower-layer", "tokio/sync"]
 client-proxy = ["client", "dep:base64", "dep:ipnet", "dep:percent-encoding"]
 client-proxy-system = ["dep:system-configuration", "dep:windows-registry"]
 


### PR DESCRIPTION
`client-pool` never actually uses `tokio/net`, only `tokio/sync`. This allows usage of `client-pool` unchanged on WASM.

Related to #268, but hopefully a better strategy since it moves the dependency to where it's actually used.