### PR TITLE
Add http2_max_local_error_reset_streams method to legacy client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ futures-channel = { version = "0.3", optional = true }
 futures-util = { version = "0.3.16", default-features = false, optional = true }
 http = "1.0"
 http-body = "1.0.0"
-hyper = "1.8.0"
+hyper = "1.9.0"
 ipnet = { version = "2.9", optional = true }
 libc = { version = "0.2", optional = true }
 percent-encoding = { version = "2.3", optional = true }

--- a/src/client/legacy/client.rs
+++ b/src/client/legacy/client.rs
@@ -1512,6 +1512,24 @@ impl Builder {
         self
     }
 
+    /// Configures the maximum number of local resets due to protocol errors made by the remote end.
+    ///
+    /// See the documentation of [`h2::client::Builder::max_local_error_reset_streams`] for more
+    /// details.
+    ///
+    /// The default value is determined by the `h2` crate.
+    ///
+    /// [`h2::client::Builder::max_local_error_reset_streams`]: https://docs.rs/h2/latest/h2/client/struct.Builder.html#method.max_local_error_reset_streams
+    #[cfg(feature = "http2")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
+    pub fn http2_max_local_error_reset_streams(
+        &mut self,
+        max: impl Into<Option<usize>>,
+    ) -> &mut Self {
+        self.h2_builder.max_local_error_reset_streams(max);
+        self
+    }
+
     /// Sets the `SETTINGS_MAX_CONCURRENT_STREAMS` option for HTTP2 connections.
     ///
     /// Passing `None` will do nothing.


### PR DESCRIPTION
Expose the h2 `max_local_error_reset_streams` setting on the legacy client builder, allowing users to configure the maximum number of locally-reset streams before a GOAWAY frame is sent.