### PR TITLE
feat(server,http1,http2,upgrade): remove body static lifetime constraint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ futures-channel = { version = "0.3", optional = true }
 futures-util = { version = "0.3.16", default-features = false, optional = true }
 http = "1.0"
 http-body = "1.0.0"
-hyper = { git = "https://github.com/Voldemat/hyper.git", rev = "b026239" }
+hyper = { git = "https://github.com/Voldemat/hyper.git", rev = "b0262393" }
 ipnet = { version = "2.9", optional = true }
 libc = { version = "0.2", optional = true }
 percent-encoding = { version = "2.3", optional = true }
@@ -36,7 +36,7 @@ tower-layer = { version = "0.3", optional = true }
 tower-service = { version = "0.3", optional = true }
 
 [dev-dependencies]
-hyper = { git = "https://github.com/Voldemat/hyper.git", features = ["full"], rev = "b026239" }
+hyper = { git = "https://github.com/Voldemat/hyper.git", features = ["full"], rev = "b0262393" }
 bytes = "1"
 futures-util = { version = "0.3.16", default-features = false, features = ["alloc"] }
 http-body-util = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ futures-channel = { version = "0.3", optional = true }
 futures-util = { version = "0.3.16", default-features = false, optional = true }
 http = "1.0"
 http-body = "1.0.0"
-hyper = { git = "https://github.com/Voldemat/hyper.git" }
+hyper = { git = "https://github.com/Voldemat/hyper.git", rev = "b026239" }
 ipnet = { version = "2.9", optional = true }
 libc = { version = "0.2", optional = true }
 percent-encoding = { version = "2.3", optional = true }
@@ -36,7 +36,7 @@ tower-layer = { version = "0.3", optional = true }
 tower-service = { version = "0.3", optional = true }
 
 [dev-dependencies]
-hyper = { git = "https://github.com/Voldemat/hyper.git", features = ["full"] }
+hyper = { git = "https://github.com/Voldemat/hyper.git", features = ["full"], rev = "b026239" }
 bytes = "1"
 futures-util = { version = "0.3.16", default-features = false, features = ["alloc"] }
 http-body-util = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ futures-channel = { version = "0.3", optional = true }
 futures-util = { version = "0.3.16", default-features = false, optional = true }
 http = "1.0"
 http-body = "1.0.0"
-hyper = { git = "https://github.com/Voldemat/hyper.git", rev = "2981d85039259e162f1162fb7422f94adc5f3bdb" }
+hyper = { git = "https://github.com/Voldemat/hyper.git" }
 ipnet = { version = "2.9", optional = true }
 libc = { version = "0.2", optional = true }
 percent-encoding = { version = "2.3", optional = true }
@@ -36,7 +36,7 @@ tower-layer = { version = "0.3", optional = true }
 tower-service = { version = "0.3", optional = true }
 
 [dev-dependencies]
-hyper = { git = "https://github.com/Voldemat/hyper.git", rev = "2981d85039259e162f1162fb7422f94adc5f3bdb", features = ["full"] }
+hyper = { git = "https://github.com/Voldemat/hyper.git", features = ["full"] }
 bytes = "1"
 futures-util = { version = "0.3.16", default-features = false, features = ["alloc"] }
 http-body-util = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ futures-channel = { version = "0.3", optional = true }
 futures-util = { version = "0.3.16", default-features = false, optional = true }
 http = "1.0"
 http-body = "1.0.0"
-hyper = "1.9.0"
+hyper = { git = "https://github.com/Voldemat/hyper.git", rev = "2981d85039259e162f1162fb7422f94adc5f3bdb" }
 ipnet = { version = "2.9", optional = true }
 libc = { version = "0.2", optional = true }
 percent-encoding = { version = "2.3", optional = true }
@@ -36,7 +36,7 @@ tower-layer = { version = "0.3", optional = true }
 tower-service = { version = "0.3", optional = true }
 
 [dev-dependencies]
-hyper = { version = "1.4.0", features = ["full"] }
+hyper = { git = "https://github.com/Voldemat/hyper.git", rev = "2981d85039259e162f1162fb7422f94adc5f3bdb", features = ["full"] }
 bytes = "1"
 futures-util = { version = "0.3.16", default-features = false, features = ["alloc"] }
 http-body-util = "0.1.0"

--- a/src/server/conn/auto/mod.rs
+++ b/src/server/conn/auto/mod.rs
@@ -219,12 +219,16 @@ impl<E> Builder<E> {
     }
 
     /// Bind a connection together with a [`Service`].
-    pub fn serve_connection<I, S, B>(&self, io: I, service: S) -> Connection<'_, I, S, E>
+    pub fn serve_connection<'body, I, S, B>(
+        &self,
+        io: I,
+        service: S,
+    ) -> Connection<'_, 'body, I, S, E>
     where
         S: Service<Request<Incoming>, Response = Response<B>>,
         S::Future: 'static,
         S::Error: Into<Box<dyn StdError + Send + Sync>>,
-        B: Body + 'static,
+        B: Body + 'body,
         B::Error: Into<Box<dyn StdError + Send + Sync>>,
         I: Read + Write + Unpin + 'static,
         E: HttpServerConnExec<S::Future, B>,
@@ -262,16 +266,16 @@ impl<E> Builder<E> {
     /// instead. See the documentation of the latter to understand why.
     ///
     /// [`hyper_util::server::conn::auto::upgrade::downcast`]: crate::server::conn::auto::upgrade::downcast
-    pub fn serve_connection_with_upgrades<I, S, B>(
+    pub fn serve_connection_with_upgrades<'body, I, S, B>(
         &self,
         io: I,
         service: S,
-    ) -> UpgradeableConnection<'_, I, S, E>
+    ) -> UpgradeableConnection<'_, 'body, I, S, E>
     where
         S: Service<Request<Incoming>, Response = Response<B>>,
         S::Future: 'static,
         S::Error: Into<Box<dyn StdError + Send + Sync>>,
-        B: Body + 'static,
+        B: Body + 'body,
         B::Error: Into<Box<dyn StdError + Send + Sync>>,
         I: Read + Write + Unpin + Send + 'static,
         E: HttpServerConnExec<S::Future, B>,
@@ -387,12 +391,12 @@ pin_project! {
     /// To drive HTTP on this connection this future **must be polled**, typically with
     /// `.await`. If it isn't polled, no progress will be made on this connection.
     #[must_use = "futures do nothing unless polled"]
-    pub struct Connection<'a, I, S, E>
+    pub struct Connection<'a, 'body, I, S, E>
     where
         S: HttpService<Incoming>,
     {
         #[pin]
-        state: ConnState<'a, I, S, E>,
+        state: ConnState<'a, 'body, I, S, E>,
     }
 }
 
@@ -413,20 +417,21 @@ impl<T> std::ops::Deref for Cow<'_, T> {
 }
 
 #[cfg(feature = "http1")]
-type Http1Connection<I, S> = hyper::server::conn::http1::Connection<Rewind<I>, S>;
+type Http1Connection<'body, I, S> = hyper::server::conn::http1::Connection<'body, Rewind<I>, S>;
 
 #[cfg(not(feature = "http1"))]
 type Http1Connection<I, S> = (PhantomData<I>, PhantomData<S>);
 
 #[cfg(feature = "http2")]
-type Http2Connection<I, S, E> = hyper::server::conn::http2::Connection<Rewind<I>, S, E>;
+type Http2Connection<'body, I, S, E> =
+    hyper::server::conn::http2::Connection<'body, Rewind<I>, S, E>;
 
 #[cfg(not(feature = "http2"))]
-type Http2Connection<I, S, E> = (PhantomData<I>, PhantomData<S>, PhantomData<E>);
+type Http2Connection<'body, I, S, E> = (PhantomData<I>, PhantomData<S>, PhantomData<E>);
 
 pin_project! {
     #[project = ConnStateProj]
-    enum ConnState<'a, I, S, E>
+    enum ConnState<'a, 'body, I, S, E>
     where
         S: HttpService<Incoming>,
     {
@@ -438,21 +443,21 @@ pin_project! {
         },
         H1 {
             #[pin]
-            conn: Http1Connection<I, S>,
+            conn: Http1Connection<'body, I, S>,
         },
         H2 {
             #[pin]
-            conn: Http2Connection<I, S, E>,
+            conn: Http2Connection<'body, I, S, E>,
         },
     }
 }
 
-impl<I, S, E, B> Connection<'_, I, S, E>
+impl<'body, I, S, E, B> Connection<'_, 'body, I, S, E>
 where
-    S: HttpService<Incoming, ResBody = B>,
+    S: HttpService<Incoming, ResBody = B> + 'body,
     S::Error: Into<Box<dyn StdError + Send + Sync>>,
-    I: Read + Write + Unpin,
-    B: Body + 'static,
+    I: Read + Write + Unpin + 'body,
+    B: Body + 'body,
     B::Error: Into<Box<dyn StdError + Send + Sync>>,
     E: HttpServerConnExec<S::Future, B>,
 {
@@ -477,7 +482,7 @@ where
     }
 
     /// Make this Connection static, instead of borrowing from Builder.
-    pub fn into_owned(self) -> Connection<'static, I, S, E>
+    pub fn into_owned(self) -> Connection<'static, 'body, I, S, E>
     where
         Builder<E>: Clone,
     {
@@ -503,12 +508,12 @@ where
     }
 }
 
-impl<I, S, E, B> Future for Connection<'_, I, S, E>
+impl<'body, I, S, E, B> Future for Connection<'_, 'body, I, S, E>
 where
     S: Service<Request<Incoming>, Response = Response<B>>,
     S::Future: 'static,
     S::Error: Into<Box<dyn StdError + Send + Sync>>,
-    B: Body + 'static,
+    B: Body + 'body,
     B::Error: Into<Box<dyn StdError + Send + Sync>>,
     I: Read + Write + Unpin + 'static,
     E: HttpServerConnExec<S::Future, B>,
@@ -564,24 +569,25 @@ pin_project! {
     /// To drive HTTP on this connection this future **must be polled**, typically with
     /// `.await`. If it isn't polled, no progress will be made on this connection.
     #[must_use = "futures do nothing unless polled"]
-    pub struct UpgradeableConnection<'a, I, S, E>
+    pub struct UpgradeableConnection<'a, 'body, I, S, E>
     where
         S: HttpService<Incoming>,
     {
         #[pin]
-        state: UpgradeableConnState<'a, I, S, E>,
+        state: UpgradeableConnState<'a, 'body, I, S, E>,
     }
 }
 
 #[cfg(feature = "http1")]
-type Http1UpgradeableConnection<I, S> = hyper::server::conn::http1::UpgradeableConnection<I, S>;
+type Http1UpgradeableConnection<'body, I, S> =
+    hyper::server::conn::http1::UpgradeableConnection<'body, I, S>;
 
 #[cfg(not(feature = "http1"))]
 type Http1UpgradeableConnection<I, S> = (PhantomData<I>, PhantomData<S>);
 
 pin_project! {
     #[project = UpgradeableConnStateProj]
-    enum UpgradeableConnState<'a, I, S, E>
+    enum UpgradeableConnState<'a, 'body, I, S, E>
     where
         S: HttpService<Incoming>,
     {
@@ -593,21 +599,21 @@ pin_project! {
         },
         H1 {
             #[pin]
-            conn: Http1UpgradeableConnection<Rewind<I>, S>,
+            conn: Http1UpgradeableConnection<'body, Rewind<I>, S>,
         },
         H2 {
             #[pin]
-            conn: Http2Connection<I, S, E>,
+            conn: Http2Connection<'body, I, S, E>,
         },
     }
 }
 
-impl<I, S, E, B> UpgradeableConnection<'_, I, S, E>
+impl<'body, I, S, E, B> UpgradeableConnection<'_, 'body, I, S, E>
 where
-    S: HttpService<Incoming, ResBody = B>,
+    S: HttpService<Incoming, ResBody = B> + 'body,
     S::Error: Into<Box<dyn StdError + Send + Sync>>,
-    I: Read + Write + Unpin,
-    B: Body + 'static,
+    I: Read + Write + Unpin + 'body,
+    B: Body + 'body,
     B::Error: Into<Box<dyn StdError + Send + Sync>>,
     E: HttpServerConnExec<S::Future, B>,
 {
@@ -632,7 +638,7 @@ where
     }
 
     /// Make this Connection static, instead of borrowing from Builder.
-    pub fn into_owned(self) -> UpgradeableConnection<'static, I, S, E>
+    pub fn into_owned(self) -> UpgradeableConnection<'static, 'body, I, S, E>
     where
         Builder<E>: Clone,
     {
@@ -658,12 +664,12 @@ where
     }
 }
 
-impl<I, S, E, B> Future for UpgradeableConnection<'_, I, S, E>
+impl<'body, I, S, E, B> Future for UpgradeableConnection<'_, 'body, I, S, E>
 where
-    S: Service<Request<Incoming>, Response = Response<B>>,
+    S: Service<Request<Incoming>, Response = Response<B>> + 'body,
     S::Future: 'static,
     S::Error: Into<Box<dyn StdError + Send + Sync>>,
-    B: Body + 'static,
+    B: Body + 'body,
     B::Error: Into<Box<dyn StdError + Send + Sync>>,
     I: Read + Write + Unpin + Send + 'static,
     E: HttpServerConnExec<S::Future, B>,
@@ -913,11 +919,11 @@ impl<E> Http1Builder<'_, E> {
     /// handle HTTP upgrades. This requires that the IO object implements
     /// `Send`.
     #[cfg(feature = "http2")]
-    pub fn serve_connection_with_upgrades<I, S, B>(
+    pub fn serve_connection_with_upgrades<'body, I, S, B>(
         &self,
         io: I,
         service: S,
-    ) -> UpgradeableConnection<'_, I, S, E>
+    ) -> UpgradeableConnection<'_, 'body, I, S, E>
     where
         S: Service<Request<Incoming>, Response = Response<B>>,
         S::Future: 'static,
@@ -1099,12 +1105,12 @@ impl<E> Http2Builder<'_, E> {
     }
 
     /// Bind a connection together with a [`Service`].
-    pub async fn serve_connection<I, S, B>(&self, io: I, service: S) -> Result<()>
+    pub async fn serve_connection<'body, I, S, B>(&self, io: I, service: S) -> Result<()>
     where
         S: Service<Request<Incoming>, Response = Response<B>>,
         S::Future: 'static,
         S::Error: Into<Box<dyn StdError + Send + Sync>>,
-        B: Body + 'static,
+        B: Body + 'body,
         B::Error: Into<Box<dyn StdError + Send + Sync>>,
         I: Read + Write + Unpin + 'static,
         E: HttpServerConnExec<S::Future, B>,
@@ -1115,16 +1121,16 @@ impl<E> Http2Builder<'_, E> {
     /// Bind a connection together with a [`Service`], with the ability to
     /// handle HTTP upgrades. This requires that the IO object implements
     /// `Send`.
-    pub fn serve_connection_with_upgrades<I, S, B>(
+    pub fn serve_connection_with_upgrades<'body, I, S, B>(
         &self,
         io: I,
         service: S,
-    ) -> UpgradeableConnection<'_, I, S, E>
+    ) -> UpgradeableConnection<'_, 'body, I, S, E>
     where
         S: Service<Request<Incoming>, Response = Response<B>>,
         S::Future: 'static,
         S::Error: Into<Box<dyn StdError + Send + Sync>>,
-        B: Body + 'static,
+        B: Body + 'body,
         B::Error: Into<Box<dyn StdError + Send + Sync>>,
         I: Read + Write + Unpin + Send + 'static,
         E: HttpServerConnExec<S::Future, B>,

--- a/src/server/graceful.rs
+++ b/src/server/graceful.rs
@@ -163,12 +163,12 @@ pub trait GracefulConnection: Future<Output = Result<(), Self::Error>> + private
 }
 
 #[cfg(feature = "http1")]
-impl<I, B, S> GracefulConnection for hyper::server::conn::http1::Connection<I, S>
+impl<'body, I, B, S> GracefulConnection for hyper::server::conn::http1::Connection<'body, I, S>
 where
-    S: hyper::service::HttpService<hyper::body::Incoming, ResBody = B>,
+    S: hyper::service::HttpService<hyper::body::Incoming, ResBody = B> + 'body,
     S::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
     I: hyper::rt::Read + hyper::rt::Write + Unpin + 'static,
-    B: hyper::body::Body + 'static,
+    B: hyper::body::Body + 'body,
     B::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
 {
     type Error = hyper::Error;
@@ -179,12 +179,13 @@ where
 }
 
 #[cfg(feature = "http2")]
-impl<I, B, S, E> GracefulConnection for hyper::server::conn::http2::Connection<I, S, E>
+impl<'body, I, B, S, E> GracefulConnection
+    for hyper::server::conn::http2::Connection<'body, I, S, E>
 where
     S: hyper::service::HttpService<hyper::body::Incoming, ResBody = B>,
     S::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
     I: hyper::rt::Read + hyper::rt::Write + Unpin + 'static,
-    B: hyper::body::Body + 'static,
+    B: hyper::body::Body + 'body,
     B::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
     E: hyper::rt::bounds::Http2ServerConnExec<S::Future, B>,
 {
@@ -196,13 +197,15 @@ where
 }
 
 #[cfg(feature = "server-auto")]
-impl<I, B, S, E> GracefulConnection for crate::server::conn::auto::Connection<'_, I, S, E>
+impl<'body, I, B, S, E> GracefulConnection
+    for crate::server::conn::auto::Connection<'_, 'body, I, S, E>
 where
-    S: hyper::service::Service<http::Request<hyper::body::Incoming>, Response = http::Response<B>>,
+    S: hyper::service::Service<http::Request<hyper::body::Incoming>, Response = http::Response<B>>
+        + 'body,
     S::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
     S::Future: 'static,
     I: hyper::rt::Read + hyper::rt::Write + Unpin + 'static,
-    B: hyper::body::Body + 'static,
+    B: hyper::body::Body + 'body,
     B::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
     E: hyper::rt::bounds::Http2ServerConnExec<S::Future, B>,
 {
@@ -214,10 +217,11 @@ where
 }
 
 #[cfg(feature = "server-auto")]
-impl<I, B, S, E> GracefulConnection
-    for crate::server::conn::auto::UpgradeableConnection<'_, I, S, E>
+impl<'body, I, B, S, E> GracefulConnection
+    for crate::server::conn::auto::UpgradeableConnection<'_, 'body, I, S, E>
 where
-    S: hyper::service::Service<http::Request<hyper::body::Incoming>, Response = http::Response<B>>,
+    S: hyper::service::Service<http::Request<hyper::body::Incoming>, Response = http::Response<B>>
+        + 'body,
     S::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
     S::Future: 'static,
     I: hyper::rt::Read + hyper::rt::Write + Unpin + Send + 'static,
@@ -236,41 +240,41 @@ mod private {
     pub trait Sealed {}
 
     #[cfg(feature = "http1")]
-    impl<I, B, S> Sealed for hyper::server::conn::http1::Connection<I, S>
+    impl<'body, I, B, S> Sealed for hyper::server::conn::http1::Connection<'body, I, S>
     where
         S: hyper::service::HttpService<hyper::body::Incoming, ResBody = B>,
         S::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
         I: hyper::rt::Read + hyper::rt::Write + Unpin + 'static,
-        B: hyper::body::Body + 'static,
+        B: hyper::body::Body + 'body,
         B::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
     {
     }
 
     #[cfg(feature = "http1")]
-    impl<I, B, S> Sealed for hyper::server::conn::http1::UpgradeableConnection<I, S>
+    impl<'body, I, B, S> Sealed for hyper::server::conn::http1::UpgradeableConnection<'body, I, S>
     where
-        S: hyper::service::HttpService<hyper::body::Incoming, ResBody = B>,
+        S: hyper::service::HttpService<hyper::body::Incoming, ResBody = B> + 'body,
         S::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
         I: hyper::rt::Read + hyper::rt::Write + Unpin + 'static,
-        B: hyper::body::Body + 'static,
+        B: hyper::body::Body + 'body,
         B::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
     {
     }
 
     #[cfg(feature = "http2")]
-    impl<I, B, S, E> Sealed for hyper::server::conn::http2::Connection<I, S, E>
+    impl<'body, I, B, S, E> Sealed for hyper::server::conn::http2::Connection<'body, I, S, E>
     where
         S: hyper::service::HttpService<hyper::body::Incoming, ResBody = B>,
         S::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
         I: hyper::rt::Read + hyper::rt::Write + Unpin + 'static,
-        B: hyper::body::Body + 'static,
+        B: hyper::body::Body + 'body,
         B::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
         E: hyper::rt::bounds::Http2ServerConnExec<S::Future, B>,
     {
     }
 
     #[cfg(feature = "server-auto")]
-    impl<I, B, S, E> Sealed for crate::server::conn::auto::Connection<'_, I, S, E>
+    impl<'body, I, B, S, E> Sealed for crate::server::conn::auto::Connection<'_, 'body, I, S, E>
     where
         S: hyper::service::Service<
             http::Request<hyper::body::Incoming>,
@@ -279,14 +283,15 @@ mod private {
         S::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
         S::Future: 'static,
         I: hyper::rt::Read + hyper::rt::Write + Unpin + 'static,
-        B: hyper::body::Body + 'static,
+        B: hyper::body::Body + 'body,
         B::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
         E: hyper::rt::bounds::Http2ServerConnExec<S::Future, B>,
     {
     }
 
     #[cfg(feature = "server-auto")]
-    impl<I, B, S, E> Sealed for crate::server::conn::auto::UpgradeableConnection<'_, I, S, E>
+    impl<'body, I, B, S, E> Sealed
+        for crate::server::conn::auto::UpgradeableConnection<'_, 'body, I, S, E>
     where
         S: hyper::service::Service<
             http::Request<hyper::body::Incoming>,
@@ -295,7 +300,7 @@ mod private {
         S::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
         S::Future: 'static,
         I: hyper::rt::Read + hyper::rt::Write + Unpin + Send + 'static,
-        B: hyper::body::Body + 'static,
+        B: hyper::body::Body + 'body,
         B::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
         E: hyper::rt::bounds::Http2ServerConnExec<S::Future, B>,
     {


### PR DESCRIPTION
Before this change, hyper expects body trait implementation to have 'static lifetime, which prevents use cases where one might have StreamBody that references certain state that outlives hyper connection object. This change adds lifetime parameter 'body to varies hyper objects that replaces 'static.