### PR TITLE
fix: fix is_cancelled checked error

### DIFF
--- a/src/client/legacy/pool.rs
+++ b/src/client/legacy/pool.rs
@@ -608,7 +608,7 @@ pub enum Error {
 
 impl Error {
     pub(super) fn is_canceled(&self) -> bool {
-        matches!(self, Error::CheckedOutClosedValue)
+        matches!(self, Error::CheckoutNoLongerWanted)
     }
 }
 


### PR DESCRIPTION
Reading from the [code](https://github.com/hyperium/hyper-util/blob/8ae9e8b1e338a5b7d35155a0dc3708cfd94bcae2/src/client/legacy/pool.rs#L620), `CheckoutNoLongerWanted` indicates cancellation.