### PR TITLE
chore(dependencies): bump socket2 to 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ ipnet = { version = "2.9", optional = true }
 libc = { version = "0.2", optional = true }
 percent-encoding = { version = "2.3", optional = true }
 pin-project-lite = "0.2.4"
-socket2 = { version = ">=0.5.9, <0.7", optional = true, features = ["all"] }
+socket2 = { version = "0.6", optional = true, features = ["all"] }
 tracing = { version = "0.1", default-features = false, features = ["std"], optional = true }
 tokio = { version = "1", optional = true, default-features = false  }
 tower-layer = { version = "0.3", optional = true }


### PR DESCRIPTION
Closes https://github.com/hyperium/hyper/issues/4058