### PR TITLE
feat(client): add iOS system proxy detection via CFNetworkCopySystemProxySettings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,9 @@ pnet_datalink = "0.35.0"
 [target.'cfg(target_os = "macos")'.dependencies]
 system-configuration = { version = "0.7", optional = true }
 
+[target.'cfg(target_os = "ios")'.dependencies]
+core-foundation = { version = "0.9", optional = true }
+
 [target.'cfg(windows)'.dependencies]
 windows-registry = { version = ">=0.3, <0.7", optional = true }
 
@@ -78,7 +81,7 @@ client = ["hyper/client", "dep:tracing", "dep:futures-channel", "dep:tower-servi
 client-legacy = ["client", "tokio/net", "dep:socket2", "tokio/sync", "dep:libc", "dep:futures-util"]
 client-pool = ["client", "dep:futures-util", "dep:tower-layer", "tokio/sync"]
 client-proxy = ["client", "dep:base64", "dep:ipnet", "dep:percent-encoding"]
-client-proxy-system = ["dep:system-configuration", "dep:windows-registry"]
+client-proxy-system = ["dep:system-configuration", "dep:windows-registry", "dep:core-foundation"]
 
 server = ["hyper/server"]
 server-auto = ["server", "http1", "http2"]

--- a/src/client/proxy/matcher.rs
+++ b/src/client/proxy/matcher.rs
@@ -242,6 +242,9 @@ impl Builder {
         #[cfg(all(feature = "client-proxy-system", target_os = "macos"))]
         mac::with_system(&mut builder);
 
+        #[cfg(all(feature = "client-proxy-system", target_os = "ios"))]
+        ios::with_system(&mut builder);
+
         #[cfg(all(feature = "client-proxy-system", windows))]
         win::with_system(&mut builder);
 
@@ -656,6 +659,86 @@ mod mac {
         }
 
         None
+    }
+}
+
+#[cfg(feature = "client-proxy-system")]
+#[cfg(target_os = "ios")]
+mod ios {
+    use core_foundation::base::{CFType, CFTypeRef, TCFType};
+    use core_foundation::dictionary::CFDictionary;
+    use core_foundation::number::CFNumber;
+    use core_foundation::string::{CFString, CFStringRef};
+
+    #[link(name = "CFNetwork", kind = "framework")]
+    unsafe extern "C" {
+        fn CFNetworkCopySystemProxySettings() -> CFTypeRef;
+        static kCFNetworkProxiesHTTPEnable: CFStringRef;
+        static kCFNetworkProxiesHTTPProxy: CFStringRef;
+        static kCFNetworkProxiesHTTPPort: CFStringRef;
+        static kCFNetworkProxiesHTTPSEnable: CFStringRef;
+        static kCFNetworkProxiesHTTPSProxy: CFStringRef;
+        static kCFNetworkProxiesHTTPSPort: CFStringRef;
+    }
+
+    pub(super) fn with_system(builder: &mut super::Builder) {
+        unsafe {
+            let raw = CFNetworkCopySystemProxySettings();
+            if raw.is_null() {
+                return;
+            }
+            let dict: CFDictionary<CFString, CFType> =
+                CFDictionary::wrap_under_create_rule(raw as _);
+            if builder.http.is_empty() {
+                if let Some(proxy) = parse_proxy(
+                    &dict,
+                    kCFNetworkProxiesHTTPEnable,
+                    kCFNetworkProxiesHTTPProxy,
+                    kCFNetworkProxiesHTTPPort,
+                ) {
+                    builder.http = proxy;
+                }
+            }
+            if builder.https.is_empty() {
+                if let Some(proxy) = parse_proxy(
+                    &dict,
+                    kCFNetworkProxiesHTTPSEnable,
+                    kCFNetworkProxiesHTTPSProxy,
+                    kCFNetworkProxiesHTTPSPort,
+                ) {
+                    builder.https = proxy;
+                }
+            }
+        }
+    }
+
+    fn parse_proxy(
+        dict: &CFDictionary<CFString, CFType>,
+        enable_key: CFStringRef,
+        host_key: CFStringRef,
+        port_key: CFStringRef,
+    ) -> Option<String> {
+        let enabled = dict
+            .find(enable_key)
+            .and_then(|v| v.downcast::<CFNumber>())
+            .and_then(|n| n.to_i32())
+            .unwrap_or(0)
+            == 1;
+        if !enabled {
+            return None;
+        }
+        let host = dict
+            .find(host_key)
+            .and_then(|v| v.downcast::<CFString>())
+            .map(|s| s.to_string())?;
+        let port = dict
+            .find(port_key)
+            .and_then(|v| v.downcast::<CFNumber>())
+            .and_then(|n| n.to_i32());
+        Some(match port {
+            Some(p) => format!("{host}:{p}"),
+            None => host,
+        })
     }
 }
 


### PR DESCRIPTION
## iOS system proxy support

`from_system()` already reads system proxy settings on macOS (via `SCDynamicStore`) and Windows (via the registry). This PR adds a parallel implementation for iOS using `CFNetworkCopySystemProxySettings()` from CFNetwork.framework, so that callers get the same automatic proxy pickup on iOS that they already get on macOS.

### What changed

- Added `ios::with_system(&mut builder)` call in `from_system()`, gated on `#[cfg(all(feature = "client-proxy-system", target_os = "ios"))]`.
- Added `mod ios`, which declares `CFNetworkCopySystemProxySettings` and the `kCFNetworkProxies*` key constants via `unsafe extern "C"` linking against CFNetwork.framework.

### Testing

- `cargo check --features client-proxy,client-proxy-system` (macOS host): clean.
- `cargo check --target aarch64-apple-ios --features client-proxy,client-proxy-system`: clean.
- Built the test suite for `aarch64-apple-ios-sim` with `cargo test --target aarch64-apple-ios-sim --features client-proxy,client-proxy-system --no-run`, then ran the binary on a booted iPhone 15 Pro simulator via `xcrun simctl spawn`. All 12 proxy matcher unit tests passed.

Note: `CFNetworkCopySystemProxySettings` returns null when no proxy is configured, which the implementation handles by returning early. Since the simulator has no proxy configured, the system path is exercised but returns early. The unit tests confirm the parsing and matching logic is correct beyond just linking cleanly. Also verified on a real device (iPad mini 6th gen) with a proxy configured -- `CFNetworkCopySystemProxySettings` returned the expected host and port.