### PR TITLE
fix(client): cancel idle interval when pool empties

### DIFF
--- a/src/client/legacy/pool.rs
+++ b/src/client/legacy/pool.rs
@@ -798,6 +798,11 @@ impl<T: Poolable + 'static, K: Key> IdleTask<T, K> {
                         if let Ok(mut inner) = inner.lock() {
                             trace!("idle interval checking for expired");
                             inner.clear_expired();
+                            if inner.idle.is_empty() {
+                                inner.idle_interval_ref = None;
+                                trace!("pool empty, canceling idle interval");
+                                return;
+                            }
                         }
                     }
 


### PR DESCRIPTION
The IdleTask is started on first connection when pool_idle_timeout is set however it is not stopped when the pool is empty leaving the event loop spinning every pool_idle_timeout ms.

I noticed this in Deno (see: https://github.com/denoland/deno/issues/29444) and the fix seems fairly small. Do you think such a change would be worth considering? Happy to work this up with test cases if so.