### PR TITLE
feat(client): add idle-management methods to the composable pool Cache

### DIFF
--- a/src/client/pool/cache.rs
+++ b/src/client/pool/cache.rs
@@ -173,6 +173,34 @@ mod internal {
         pub fn is_empty(&self) -> bool {
             self.shared.lock().unwrap().services.is_empty()
         }
+
+        /// Remove and return one idle cached service, if any.
+        ///
+        /// Unlike [`Service::call`], which wraps the taken service in a
+        /// [`Cached`] that returns to the pool on drop, this hands back the
+        /// raw service with no return-to-pool wrapper: dropping it drops the
+        /// service outright. Use it to release the resource an idle service
+        /// holds proactively, rather than waiting for it to be handed out
+        /// again or evicted by a [`Self::retain`] pass. Serialized against
+        /// `retain` by the shared lock, so a popped service is removed before
+        /// a retain pass can observe it.
+        pub fn try_pop_idle(&self) -> Option<M::Response> {
+            self.shared.lock().unwrap().services.pop()
+        }
+
+        /// Take one idle cached service, if any, wrapped so it returns to the
+        /// pool on drop.
+        ///
+        /// Unlike [`Self::try_pop_idle`], which hands back the raw service,
+        /// this returns the same [`Cached`] wrapper [`Service::call`]
+        /// produces: dropping it re-inserts the service into the pool. Unlike
+        /// [`Service::call`], it never makes a new service — it returns `None`
+        /// when no service is idle. Serialized against [`Self::retain`] and
+        /// [`Self::try_pop_idle`] by the shared lock.
+        pub fn try_checkout_idle(&self) -> Option<Cached<M::Response>> {
+            let inner = self.shared.lock().unwrap().services.pop()?;
+            Some(Cached::new(inner, Arc::downgrade(&self.shared)))
+        }
     }
 
     impl<M, Dst, Ev> Service<Dst> for Cache<M, Dst, Ev>
@@ -312,6 +340,17 @@ mod internal {
         /// Get a mutable reference to the inner service.
         pub fn inner_mut(&mut self) -> &mut S {
             self.inner.as_mut().expect("inner only taken in drop")
+        }
+
+        /// Prevent this cached service from being returned to the pool.
+        ///
+        /// Consumes `self`; the inner service is dropped without reinsertion,
+        /// regardless of whether it is still healthy. Use it when the caller
+        /// has learned the service should not be reused after checkout — for
+        /// example a connection the peer has signalled it will close — without
+        /// having to force its `poll_ready` to error to skip reinsertion.
+        pub fn discard(mut self) {
+            self.is_closed = true;
         }
     }
 
@@ -490,5 +529,96 @@ mod tests {
         let f = cache.call(1);
         let cached = f.await.expect("call");
         drop(cached);
+    }
+
+    #[tokio::test]
+    async fn test_discard_prevents_reuse() {
+        let (mock, mut handle) = tower_test::mock::pair();
+        let mut cache = super::builder().build(mock);
+        handle.allow(1);
+
+        std::future::poll_fn(|cx| cache.poll_ready(cx))
+            .await
+            .unwrap();
+        let cached = future::join(cache.call(1), async {
+            assert_request_eq!(handle, 1).send_response("one");
+        })
+        .await
+        .0
+        .expect("call");
+
+        // Discarding (rather than dropping) must not return the service to the
+        // pool: the idle set stays empty.
+        cached.discard();
+        assert!(cache.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_try_pop_idle_removes_one() {
+        let (mock, mut handle) = tower_test::mock::pair();
+        let mut cache = super::builder().build(mock);
+        handle.allow(1);
+
+        std::future::poll_fn(|cx| cache.poll_ready(cx))
+            .await
+            .unwrap();
+        let cached = future::join(cache.call(1), async {
+            assert_request_eq!(handle, 1).send_response("one");
+        })
+        .await
+        .0
+        .expect("call");
+        // Returning the checkout to the pool leaves one idle service.
+        drop(cached);
+        assert!(!cache.is_empty());
+
+        // The idle service is popped and the cache is left empty.
+        assert!(cache.try_pop_idle().is_some());
+        assert!(cache.is_empty());
+        // Nothing left to pop.
+        assert!(cache.try_pop_idle().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_try_checkout_idle_returns_to_pool_on_drop() {
+        let (mock, mut handle) = tower_test::mock::pair();
+        let mut cache = super::builder().build(mock);
+        // Only one service is ever made: a successful checkout-and-reuse must
+        // not start a second connection.
+        handle.allow(1);
+
+        std::future::poll_fn(|cx| cache.poll_ready(cx))
+            .await
+            .unwrap();
+        let cached = future::join(cache.call(1), async {
+            assert_request_eq!(handle, 1).send_response("one");
+        })
+        .await
+        .0
+        .expect("call");
+        drop(cached);
+        assert!(!cache.is_empty());
+
+        // Checking out the idle service removes it from the idle set.
+        let checked_out = cache.try_checkout_idle();
+        assert!(checked_out.is_some());
+        assert!(cache.is_empty());
+
+        // Dropping the checkout returns the service to the pool (unlike
+        // `try_pop_idle`), so it can be checked out again — and since only one
+        // service was ever made, this reuses the same one.
+        drop(checked_out);
+        assert!(!cache.is_empty());
+        assert!(cache.try_checkout_idle().is_some());
+    }
+
+    #[tokio::test]
+    async fn test_try_take_idle_on_empty_cache_is_none() {
+        let (mock, _handle) = tower_test::mock::pair::<i32, &'static str>();
+        let cache = super::builder().build(mock);
+
+        // No idle service. Unlike `Service::call`, neither take makes a new one.
+        assert!(cache.try_checkout_idle().is_none());
+        assert!(cache.try_pop_idle().is_none());
     }
 }


### PR DESCRIPTION
Add three methods to `client::pool::Cache` / `Cached` for managing idle cached services explicitly:

- **`Cached::discard(self)`** — consume the checkout and drop the inner service without returning it to the pool.
- **`Cache::try_pop_idle()`** — remove and return one idle service, raw (no return-to-pool wrapper).
- **`Cache::try_checkout_idle()`** — take one idle service wrapped so it returns to the pool on drop, without making a new one when none is idle.

## Motivation

`Cache` currently exposes `call` (take a service, making one if the pool is empty) and `retain` (bulk eviction by predicate). Two operations a pool consumer needs have no API:

1. **Drop a checked-out service that has become unusable.** The only way to skip reinsertion on drop is for the inner service's `poll_ready` to return `Err`. A consumer that learns a service is bad *after* checkout — for a connection, the peer sent `Connection: close`, an HTTP/2 GOAWAY arrived on the response, or an error classifier fired — must either force a synthetic `poll_ready` error or let the known-bad service return to the pool. `discard` makes the intent direct and leaves `poll_ready` for readiness alone.

2. **Reach an idle service without making a new one.** `call` always produces a service, starting a new one when the pool is empty. A consumer that wants to act on existing idle capacity only — release it to free the resource it holds, or hand it out for a single use — cannot express "idle if present, otherwise nothing." `try_pop_idle` (release) and `try_checkout_idle` (single use, returns on drop) cover the two shapes.

## Solution

The three methods are thin wrappers over the existing shared service list, serialized by the same lock as `call` and `retain`:

| Method | Behavior |
| --- | --- |
| `Cached::discard(self)` | Sets the `is_closed` flag the `Drop` impl already checks, so the inner service is dropped instead of reinserted. |
| `Cache::try_pop_idle()` | Pops one entry from the idle list and returns it raw. |
| `Cache::try_checkout_idle()` | Pops one entry and wraps it in `Cached`, matching what `call` returns for an idle hit. Returns `None` rather than connecting when the pool is empty. |

No existing behavior changes.

## Tests

Added to the `cache` test module, using the existing `tower_test::mock` harness:

- `discard` prevents reinsertion (cache empty after a discarded checkout).
- `try_pop_idle` removes one idle service and does not reinsert it.
- `try_checkout_idle` returns the service to the pool on drop and makes no new service (a single connection is reused).
- both takes return `None` on an empty cache.

----

See also https://github.com/smithy-lang/smithy-rs/pull/4708 