### PR TITLE
fix(client-pool): wake cache waiters in FIFO order

### DIFF
--- a/src/client/pool/cache.rs
+++ b/src/client/pool/cache.rs
@@ -18,6 +18,7 @@ pub use self::internal::Cached;
 // more public, but we can't change type shapes (generics) once things are
 // public.
 mod internal {
+    use std::collections::VecDeque;
     use std::fmt;
     use std::future::Future;
     use std::pin::Pin;
@@ -108,7 +109,7 @@ mod internal {
     #[derive(Debug)]
     pub struct Shared<S> {
         services: Vec<S>,
-        waiters: Vec<oneshot::Sender<S>>,
+        waiters: VecDeque<oneshot::Sender<S>>,
     }
 
     // impl Builder
@@ -149,7 +150,7 @@ mod internal {
                 events: self.events,
                 shared: Arc::new(Mutex::new(Shared {
                     services: Vec::new(),
-                    waiters: Vec::new(),
+                    waiters: VecDeque::new(),
                 })),
             }
         }
@@ -205,7 +206,7 @@ mod internal {
                 }
 
                 let (tx, rx) = oneshot::channel();
-                locked.waiters.push(tx);
+                locked.waiters.push_back(tx);
                 rx
             };
 
@@ -363,7 +364,7 @@ mod internal {
     impl<V> Shared<V> {
         fn put(&mut self, val: V) {
             let mut val = Some(val);
-            while let Some(tx) = self.waiters.pop() {
+            while let Some(tx) = self.waiters.pop_front() {
                 if !tx.is_closed() {
                     match tx.send(val.take().unwrap()) {
                         Ok(()) => break,
@@ -490,5 +491,73 @@ mod tests {
         let f = cache.call(1);
         let cached = f.await.expect("call");
         drop(cached);
+    }
+
+    // A returned connection is handed to waiters in the order they parked
+    // (FIFO), so a waiter cannot be starved by later arrivals.
+    #[tokio::test]
+    async fn test_waiters_woken_in_fifo_order() {
+        use std::future::Future;
+        use std::task::{Context, Poll, Waker};
+
+        let (mock, mut handle) = tower_test::mock::pair::<u32, &'static str>();
+        let mut cache = super::builder().build(mock);
+        handle.allow(16);
+
+        // Establish one connection and hold it, so the next checkouts find no
+        // idle service and park.
+        std::future::poll_fn(|cx| cache.poll_ready(cx))
+            .await
+            .unwrap();
+        let held = future::join(cache.call(0), async {
+            assert_request_eq!(handle, 0).send_response("conn");
+        })
+        .await
+        .0
+        .expect("call");
+
+        // Park three checkouts in order. Each misses and starts a connect, but
+        // the connect is never completed, so each parks on its waiter.
+        let mut cx = Context::from_waker(Waker::noop());
+        std::future::poll_fn(|cx| cache.poll_ready(cx))
+            .await
+            .unwrap();
+        let mut first = Box::pin(cache.call(1));
+        assert!(first.as_mut().poll(&mut cx).is_pending());
+        std::future::poll_fn(|cx| cache.poll_ready(cx))
+            .await
+            .unwrap();
+        let mut second = Box::pin(cache.call(2));
+        assert!(second.as_mut().poll(&mut cx).is_pending());
+        std::future::poll_fn(|cx| cache.poll_ready(cx))
+            .await
+            .unwrap();
+        let mut third = Box::pin(cache.call(3));
+        assert!(third.as_mut().poll(&mut cx).is_pending());
+
+        // Returning the connection wakes the oldest waiter first.
+        drop(held);
+        let first = match first.as_mut().poll(&mut cx) {
+            Poll::Ready(r) => r.expect("first"),
+            Poll::Pending => panic!("oldest waiter was not woken first"),
+        };
+        assert!(second.as_mut().poll(&mut cx).is_pending());
+        assert!(third.as_mut().poll(&mut cx).is_pending());
+
+        // Returning it again wakes the next-oldest, then the last.
+        drop(first);
+        let second = match second.as_mut().poll(&mut cx) {
+            Poll::Ready(r) => r.expect("second"),
+            Poll::Pending => panic!("second waiter was not woken next"),
+        };
+        assert!(third.as_mut().poll(&mut cx).is_pending());
+
+        drop(second);
+        match third.as_mut().poll(&mut cx) {
+            Poll::Ready(r) => {
+                r.expect("third");
+            }
+            Poll::Pending => panic!("last waiter was not woken"),
+        }
     }
 }


### PR DESCRIPTION
## Problem

When a checkout misses the idle set, `Cache` parks the request as a waiter and returns a connection to it once one becomes available (`Shared::put`). Waiters were stored in a `Vec` and woken with `pop()` — last-in, first-out.

Under sustained load where the number of in-flight checkouts exceeds the number of reusable connections (e.g. a bounded connection pool), LIFO wakeup starves the oldest waiters: each returned connection goes to the most recently parked checkout, so a waiter that arrived early is repeatedly skipped in favor of newer ones. It is served only when the backlog drains. The result is unbounded tail latency — a small fraction of requests wait for the entire duration of the load while the median stays low.

## Fix

Store waiters in a `VecDeque` and wake from the front (`pop_front`), pushing new waiters to the back. A returned connection is handed to the longest-waiting checkout. Service order is now arrival order, so a waiter's worst-case wait is bounded by the number of waiters ahead of it rather than by how long the load lasts.

The change is local to `Shared`; the public API is unchanged.

## Effect

Measured with a load generator against a 2-node server fleet (H1, 8 MiB responses, 512 concurrent workers, 20s sustained), with the connection pool capped below the offered concurrency:

| max connections | P999 before (LIFO) | P999 after (FIFO) |
|---|---|---|
| 64 | 23.2s | 0.38s |
| 128 | 23.2s | 0.40s |
| 256 | 23.2s | 0.57s |
| 512 | 8.7s | 1.43s |

P50 stayed in the tens-of-ms range in both cases. Throughput (line-rate ~196 Gb/s on 8 MiB objects) was unchanged — the fix only affects which waiter is served when a connection returns, not how fast connections complete.

The P999 values before the fix pin at ~23s (the measurement window length), confirming that 0.1% of requests were never served a connection for the entire run — they starved. After the fix, every waiter advances in arrival order and P999 drops into the sub-second range.

## Test

`test_waiters_woken_in_fifo_order` parks three checkouts in order behind a held connection, then returns the connection one at a time and asserts they are woken oldest-first. It fails against the previous `Vec::pop` behavior (`oldest waiter was not woken first`) and passes with `VecDeque::pop_front`.