### PR TITLE
fix(pool): Singleton shared calls pass baton if one cancels

### DIFF
--- a/src/client/pool/singleton.rs
+++ b/src/client/pool/singleton.rs
@@ -23,10 +23,9 @@
 use std::sync::{Arc, Mutex};
 use std::task::{self, Poll};
 
-use tokio::sync::oneshot;
 use tower_service::Service;
 
-use self::internal::{DitchGuard, SingletonError, SingletonFuture, State};
+use self::internal::{SingletonError, SingletonFuture, State};
 
 type BoxError = Box<dyn std::error::Error + Send + Sync>;
 
@@ -44,7 +43,7 @@ where
     M: Service<Dst>,
 {
     mk_svc: M,
-    state: Arc<Mutex<State<M::Response>>>,
+    state: Arc<Mutex<State<M::Future, M::Response>>>,
 }
 
 impl<M, Target> Singleton<M, Target>
@@ -94,7 +93,7 @@ where
     M::Response: Clone,
     M::Error: Into<BoxError>,
 {
-    type Response = internal::Singled<M::Response>;
+    type Response = internal::Singled<M::Future, M::Response>;
     type Error = SingletonError;
     type Future = SingletonFuture<M::Future, M::Response>;
 
@@ -113,18 +112,21 @@ where
         match *locked {
             State::Empty => {
                 let fut = self.mk_svc.call(dst);
-                *locked = State::Making(Vec::new());
-                SingletonFuture::Driving {
-                    future: fut,
-                    singleton: DitchGuard(Arc::downgrade(&self.state)),
+                let mut batch = internal::Batch::new(fut);
+                let id = batch.register_driver();
+                *locked = State::Making(batch);
+                SingletonFuture::Participating {
+                    id,
+                    state: self.state.clone(),
+                    rx: None,
                 }
             }
-            State::Making(ref mut waiters) => {
-                let (tx, rx) = oneshot::channel();
-                waiters.push(tx);
-                SingletonFuture::Waiting {
-                    rx,
-                    state: Arc::downgrade(&self.state),
+            State::Making(ref mut batch) => {
+                let (id, rx) = batch.register_waiter();
+                SingletonFuture::Participating {
+                    id,
+                    state: self.state.clone(),
+                    rx: Some(rx),
                 }
             }
             State::Made(ref svc) => SingletonFuture::Made {
@@ -148,47 +150,77 @@ where
 }
 
 // Holds some "pub" items that otherwise shouldn't be public.
+/// Baton-passing implementation.
+///
+/// While a singleton service is being made, one participating future is
+/// responsible for driving that work. If that future is canceled, the work
+/// should not be canceled for every other caller waiting on the same service.
+/// Baton-passing lets another participant take over, so cancellation remains
+/// local to the future that was dropped.
 mod internal {
+    use std::fmt;
     use std::future::Future;
     use std::pin::Pin;
     use std::sync::{Arc, Mutex, Weak};
-    use std::task::{self, Poll, ready};
+    use std::task::{self, Poll, Waker};
 
-    use pin_project_lite::pin_project;
     use tokio::sync::oneshot;
     use tower_service::Service;
 
     use super::BoxError;
 
-    pin_project! {
-        #[project = SingletonFutureProj]
-        pub enum SingletonFuture<F, S> {
-            Driving {
-                #[pin]
-                future: F,
-                singleton: DitchGuard<S>,
-            },
-            Waiting {
-                rx: oneshot::Receiver<Result<S, SharedError>>,
-                state: Weak<Mutex<State<S>>>,
-            },
-            Made {
-                svc: Option<S>,
-                state: Weak<Mutex<State<S>>>,
-            },
+    pub enum SingletonFuture<F, S> {
+        Participating {
+            id: WaiterId,
+            state: Arc<Mutex<State<F, S>>>,
+            rx: Option<oneshot::Receiver<Result<S, SharedError>>>,
+        },
+        Made {
+            svc: Option<S>,
+            state: Weak<Mutex<State<F, S>>>,
+        },
+    }
+
+    impl<F, S> Unpin for SingletonFuture<F, S> {}
+
+    // XXX: pub because of the enum SingletonFuture
+    pub enum State<F, S> {
+        Empty,
+        Making(Batch<F, S>),
+        Made(S),
+    }
+
+    impl<F, S: fmt::Debug> fmt::Debug for State<F, S> {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            match self {
+                State::Empty => f.write_str("Empty"),
+                State::Making(..) => f.write_str("Making"),
+                State::Made(svc) => f.debug_tuple("Made").field(svc).finish(),
+            }
         }
     }
 
     // XXX: pub because of the enum SingletonFuture
-    #[derive(Debug)]
-    pub enum State<S> {
-        Empty,
-        Making(Vec<oneshot::Sender<Result<S, SharedError>>>),
-        Made(S),
+    pub struct Batch<F, S> {
+        future: Option<Pin<Box<F>>>,
+        next_id: WaiterId,
+        driver: Option<Driver>,
+        waiters: Vec<Waiter<S>>,
     }
 
-    // XXX: pub because of the enum SingletonFuture
-    pub struct DitchGuard<S>(pub(super) Weak<Mutex<State<S>>>);
+    #[derive(Copy, Clone, Debug, Eq, PartialEq)]
+    pub struct WaiterId(usize);
+
+    struct Driver {
+        id: WaiterId,
+        waker: Option<Waker>,
+    }
+
+    struct Waiter<S> {
+        id: WaiterId,
+        waker: Option<Waker>,
+        tx: oneshot::Sender<Result<S, SharedError>>,
+    }
 
     /// A cached service returned from a [`Singleton`].
     ///
@@ -204,9 +236,9 @@ mod internal {
     /// code. The type is exposed in the documentation to show which methods
     /// can be publicly called.
     #[derive(Debug)]
-    pub struct Singled<S> {
+    pub struct Singled<F, S> {
         inner: S,
-        state: Weak<Mutex<State<S>>>,
+        state: Weak<Mutex<State<F, S>>>,
     }
 
     impl<F, S, E> Future for SingletonFuture<F, S>
@@ -215,83 +247,77 @@ mod internal {
         E: Into<BoxError>,
         S: Clone,
     {
-        type Output = Result<Singled<S>, SingletonError>;
+        type Output = Result<Singled<F, S>, SingletonError>;
 
-        fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
-            match self.project() {
-                SingletonFutureProj::Driving { future, singleton } => {
-                    match ready!(future.poll(cx)) {
-                        Ok(svc) => {
-                            if let Some(state) = singleton.0.upgrade() {
-                                let mut locked = state.lock().unwrap();
-                                match std::mem::replace(&mut *locked, State::Made(svc.clone())) {
-                                    State::Making(waiters) => {
-                                        for tx in waiters {
-                                            let _ = tx.send(Ok(svc.clone()));
-                                        }
-                                    }
-                                    State::Empty | State::Made(_) => {
-                                        // shouldn't happen!
-                                        unreachable!()
-                                    }
-                                }
+        fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
+            match &mut *self {
+                SingletonFuture::Participating { id, state, rx } => {
+                    if let Some(receiver) = rx.as_mut() {
+                        match Pin::new(receiver).poll(cx) {
+                            Poll::Ready(Ok(Ok(svc))) => {
+                                return Poll::Ready(Ok(Singled::new(svc, Arc::downgrade(state))));
                             }
-                            // take out of the DitchGuard so it doesn't treat as "ditched"
-                            let state = std::mem::replace(&mut singleton.0, Weak::new());
-                            Poll::Ready(Ok(Singled::new(svc, state)))
+                            Poll::Ready(Ok(Err(err))) => {
+                                return Poll::Ready(Err(SingletonError(err)));
+                            }
+                            Poll::Ready(Err(_canceled)) => {
+                                *rx = None;
+                            }
+                            Poll::Pending => {}
                         }
-                        Err(e) => {
-                            let e = box_error_into_shared(e.into());
-                            if let Some(state) = singleton.0.upgrade() {
-                                let mut locked = state.lock().unwrap();
-                                singleton.0 = Weak::new();
-                                match std::mem::replace(&mut *locked, State::Empty) {
-                                    State::Making(waiters) => {
-                                        for tx in waiters {
-                                            let _ = tx.send(Err(e.clone()));
-                                        }
-                                    }
-                                    State::Empty | State::Made(_) => {
-                                        // shouldn't happen!
-                                        unreachable!()
-                                    }
-                                }
+                    }
+
+                    let state_weak = Arc::downgrade(state);
+                    let mut locked = state.lock().unwrap();
+
+                    match &mut *locked {
+                        State::Making(batch) => match batch.poll(*id, cx) {
+                            Poll::Pending => Poll::Pending,
+                            Poll::Ready(Ok(svc)) => {
+                                batch.send_result(Ok(svc.clone()));
+                                *locked = State::Made(svc.clone());
+                                Poll::Ready(Ok(Singled::new(svc, state_weak)))
                             }
-                            Poll::Ready(Err(SingletonError(e)))
+                            Poll::Ready(Err(err)) => {
+                                batch.send_result(Err(err.clone()));
+                                *locked = State::Empty;
+                                Poll::Ready(Err(SingletonError(err)))
+                            }
+                        },
+                        State::Made(svc) => Poll::Ready(Ok(Singled::new(svc.clone(), state_weak))),
+                        State::Empty => {
+                            unreachable!("singleton participant polled after making was canceled")
                         }
                     }
                 }
-                SingletonFutureProj::Waiting { rx, state } => match ready!(Pin::new(rx).poll(cx)) {
-                    Ok(Ok(svc)) => Poll::Ready(Ok(Singled::new(svc, state.clone()))),
-                    Ok(Err(e)) => Poll::Ready(Err(SingletonError(e))),
-                    Err(_canceled) => {
-                        Poll::Ready(Err(SingletonError(box_error_into_shared(Canceled.into()))))
-                    }
-                },
-                SingletonFutureProj::Made { svc, state } => {
+                SingletonFuture::Made { svc, state } => {
                     Poll::Ready(Ok(Singled::new(svc.take().unwrap(), state.clone())))
                 }
             }
         }
     }
 
-    impl<S> Drop for DitchGuard<S> {
+    impl<F, S> Drop for SingletonFuture<F, S> {
         fn drop(&mut self) {
-            if let Some(state) = self.0.upgrade() {
+            if let SingletonFuture::Participating { id, state, .. } = self {
                 if let Ok(mut locked) = state.lock() {
-                    *locked = State::Empty;
+                    if let State::Making(batch) = &mut *locked {
+                        if batch.remove(*id) {
+                            *locked = State::Empty;
+                        }
+                    }
                 }
             }
         }
     }
 
-    impl<S> Singled<S> {
-        fn new(inner: S, state: Weak<Mutex<State<S>>>) -> Self {
+    impl<F, S> Singled<F, S> {
+        fn new(inner: S, state: Weak<Mutex<State<F, S>>>) -> Self {
             Singled { inner, state }
         }
     }
 
-    impl<S, Req> Service<Req> for Singled<S>
+    impl<F, S, Req> Service<Req> for Singled<F, S>
     where
         S: Service<Req>,
     {
@@ -317,9 +343,139 @@ mod internal {
         }
     }
 
+    impl<F, S> Batch<F, S> {
+        pub(super) fn new(future: F) -> Self {
+            Batch {
+                future: Some(Box::pin(future)),
+                next_id: WaiterId(0),
+                driver: None,
+                waiters: Vec::new(),
+            }
+        }
+
+        pub(super) fn register_driver(&mut self) -> WaiterId {
+            let id = self.next_id;
+            self.next_id.0 += 1;
+            self.driver = Some(Driver { id, waker: None });
+            id
+        }
+
+        pub(super) fn register_waiter(
+            &mut self,
+        ) -> (WaiterId, oneshot::Receiver<Result<S, SharedError>>) {
+            let id = self.next_id;
+            self.next_id.0 += 1;
+            let (tx, rx) = oneshot::channel();
+            self.waiters.push(Waiter {
+                id,
+                waker: None,
+                tx,
+            });
+            (id, rx)
+        }
+
+        fn remove(&mut self, id: WaiterId) -> bool {
+            if let Some(pos) = self.waiters.iter().position(|waiter| waiter.id == id) {
+                self.waiters.swap_remove(pos);
+                return false;
+            }
+
+            if self.driver.as_ref().is_some_and(|driver| driver.id == id) {
+                if let Some(waiter) = self.waiters.pop() {
+                    let waker = waiter.waker;
+                    self.driver = Some(Driver {
+                        id: waiter.id,
+                        waker,
+                    });
+                    self.wake_driver();
+                    return false;
+                }
+
+                self.driver = None;
+                self.future = None;
+                return true;
+            }
+
+            false
+        }
+
+        fn poll<E>(
+            &mut self,
+            id: WaiterId,
+            cx: &mut task::Context<'_>,
+        ) -> Poll<Result<S, SharedError>>
+        where
+            F: Future<Output = Result<S, E>>,
+            E: Into<BoxError>,
+            S: Clone,
+        {
+            if !self.driver.as_ref().is_some_and(|driver| driver.id == id) {
+                self.store_waker(id, cx.waker());
+                return Poll::Pending;
+            }
+
+            let future = self.future.as_mut().expect("batch future missing");
+            match future.as_mut().poll(cx) {
+                Poll::Pending => {
+                    self.store_driver_waker(cx.waker());
+                    Poll::Pending
+                }
+                Poll::Ready(Ok(svc)) => {
+                    self.future = None;
+                    Poll::Ready(Ok(svc))
+                }
+                Poll::Ready(Err(err)) => {
+                    let err = box_error_into_shared(err.into());
+                    self.future = None;
+                    Poll::Ready(Err(err))
+                }
+            }
+        }
+
+        fn send_result(&mut self, result: Result<S, SharedError>)
+        where
+            S: Clone,
+        {
+            for waiter in std::mem::take(&mut self.waiters) {
+                let _ = waiter.tx.send(result.clone());
+            }
+        }
+
+        fn store_waker(&mut self, id: WaiterId, waker: &Waker) {
+            if let Some(waiter) = self.waiters.iter_mut().find(|waiter| waiter.id == id) {
+                if waiter
+                    .waker
+                    .as_ref()
+                    .is_none_or(|current| !current.will_wake(waker))
+                {
+                    waiter.waker = Some(waker.clone());
+                }
+            }
+        }
+
+        fn store_driver_waker(&mut self, waker: &Waker) {
+            if let Some(driver) = &mut self.driver {
+                if driver
+                    .waker
+                    .as_ref()
+                    .is_none_or(|current| !current.will_wake(waker))
+                {
+                    driver.waker = Some(waker.clone());
+                }
+            }
+        }
+
+        fn wake_driver(&mut self) {
+            if let Some(driver) = &mut self.driver {
+                if let Some(waker) = driver.waker.take() {
+                    waker.wake();
+                }
+            }
+        }
+    }
+
     // An opaque error type. By not exposing the type, nor being specifically
-    // Box<dyn Error>, we can _change_ the type once we no longer need the Canceled
-    // error type. This will be possible with the refactor to baton passing.
+    // Box<dyn Error>, we can change the inner representation later.
     #[derive(Debug)]
     pub struct SingletonError(pub(super) SharedError);
 
@@ -346,17 +502,6 @@ mod internal {
     fn box_error_into_shared(error: BoxError) -> SharedError {
         error.into()
     }
-
-    #[derive(Debug)]
-    struct Canceled;
-
-    impl std::fmt::Display for Canceled {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            f.write_str("singleton connection canceled")
-        }
-    }
-
-    impl std::error::Error for Canceled {}
 }
 
 #[cfg(test)]
@@ -521,9 +666,8 @@ mod tests {
         assert!(std::ptr::addr_eq(src1, src3));
     }
 
-    // TODO: this should be able to be improved with a cooperative baton refactor
     #[tokio::test]
-    async fn cancel_driver_cancels_all() {
+    async fn cancel_driver_hands_off_to_waiter() {
         let (mock_svc, mut handle) = tower_test::mock::pair::<(), &'static str>();
         let mut singleton = Singleton::new(mock_svc);
 
@@ -543,9 +687,88 @@ mod tests {
         let ((), send_response) = handle.next_request().await.unwrap();
         send_response.send_response("svc");
 
-        assert_eq!(
-            fut2.await.unwrap_err().0.to_string(),
-            "singleton connection canceled"
-        );
+        fut2.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn cancel_driver_promotes_parked_waiter() {
+        let (mock_svc, mut handle) = tower_test::mock::pair::<(), &'static str>();
+        let mut singleton = Singleton::new(mock_svc);
+
+        std::future::poll_fn(|cx| singleton.poll_ready(cx))
+            .await
+            .unwrap();
+        let mut fut1 = singleton.call(());
+        let fut2 = singleton.call(());
+
+        // Start the make future so dropping fut1 below exercises driver
+        // handoff during an in-flight connection attempt.
+        std::future::poll_fn(|cx| {
+            assert!(Pin::new(&mut fut1).poll(cx).is_pending());
+            Poll::Ready(())
+        })
+        .await;
+
+        // Poll the waiter once so it parks and stores a waker in the batch.
+        // This covers promotion of an already-parked waiter, not just a
+        // registered-but-never-polled waiter.
+        let mut waiter = tokio_test::task::spawn(fut2);
+        assert!(waiter.poll().is_pending());
+        assert!(!waiter.is_woken());
+
+        // When the driver is dropped, the promoted parked waiter must be
+        // woken so it can take over driving the shared make future.
+        drop(fut1);
+        assert!(waiter.is_woken());
+
+        // Poll after promotion, before the maker responds, so the waiter
+        // actually takes over as driver and stores its own waker.
+        assert!(waiter.poll().is_pending());
+
+        let ((), send_response) = handle.next_request().await.unwrap();
+        send_response.send_response("svc");
+
+        assert!(waiter.is_woken());
+        match waiter.poll() {
+            Poll::Ready(Ok(_)) => {}
+            other => panic!("expected promoted waiter to complete, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn cancel_all_waiters_clears_singleton() {
+        let (mock_svc, _handle) = tower_test::mock::pair::<(), &'static str>();
+        let mut singleton = Singleton::new(mock_svc);
+
+        std::future::poll_fn(|cx| singleton.poll_ready(cx))
+            .await
+            .unwrap();
+        let fut1 = singleton.call(());
+        let fut2 = singleton.call(());
+
+        drop(fut1);
+        drop(fut2);
+
+        assert!(singleton.is_empty());
+    }
+
+    #[tokio::test]
+    async fn cancel_non_driver_waiter_does_not_block_others() {
+        let (mock_svc, mut handle) = tower_test::mock::pair::<(), &'static str>();
+        let mut singleton = Singleton::new(mock_svc);
+
+        std::future::poll_fn(|cx| singleton.poll_ready(cx))
+            .await
+            .unwrap();
+        let fut1 = singleton.call(());
+        let fut2 = singleton.call(());
+        let fut3 = singleton.call(());
+        drop(fut2);
+
+        let ((), send_response) = handle.next_request().await.unwrap();
+        send_response.send_response("svc");
+
+        fut1.await.unwrap();
+        fut3.await.unwrap();
     }
 }


### PR DESCRIPTION
Previously, with a bunch of calls all funneled into a `Singleton`, the first call was the "driver", and the rest all waited for the driver to finish and send a clone to them. The downside is that if the first call canceled, all the subsequent waiters would just get a "canceled" error.

This changes to a baton-passing strategy. If the first future gets canceled, it passes the baton to keep driving the future to one of the other waiters. Only once all of them are canceled will it cancel the connection attempt.

cc @aajtodd 