### PR TITLE
Update to `tracing 0.1.36`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ percent-encoding = { version = "2.3", optional = true }
 pin-project-lite = "0.2.4"
 socket2 = { version = "0.6", optional = true, features = ["all"] }
 tracing = { version = "0.1.36", default-features = false, features = ["std"], optional = true }
-tokio = { version = "1", optional = true, default-features = false  }
+tokio = { version = "1.13", optional = true, default-features = false  }
 tower-layer = { version = "0.3", optional = true }
 tower-service = { version = "0.3", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ libc = { version = "0.2", optional = true }
 percent-encoding = { version = "2.3", optional = true }
 pin-project-lite = "0.2.4"
 socket2 = { version = "0.6", optional = true, features = ["all"] }
-tracing = { version = "0.1", default-features = false, features = ["std"], optional = true }
+tracing = { version = "0.1.36", default-features = false, features = ["std"], optional = true }
 tokio = { version = "1", optional = true, default-features = false  }
 tower-layer = { version = "0.3", optional = true }
 tower-service = { version = "0.3", optional = true }


### PR DESCRIPTION
`tracing 0.1.35` pulls in `tracing-core 0.1.27` which adopted `once_cell` over `lazy_static`, fixing some macro issues I had when I tried to compile with minimal dependencies.

`tracing 0.1.36` is explicitly guaranteed to compile with `-Zminimal-versions`. `hyper-util` explicitly does not compile against the minimal version of `tracing 0.1` as it uses misc features added between `0.1 and 0.x`. `0.1.36` is within `hyper-util`'s MSRV bound.

This version of `tracing` is sufficient for all my experiments I did with `-Zminimal-versions`, hence why I PR it here, but I can't confirm this is sufficient for all environments, the exact latest version of `hyper-util`, and in the future, a workflow confirming `hyper-util` compiles with `-Zminimal-versions` would be valuable. I also encountered issues with how `tower 0.4` wouldn't compile against `tower-layer 0.3` (solely `tower-layer 0.3.1`), but `tower` is no longer an explicit dependency of `hyper-util`.