### PR TITLE
fix(client): write a single NULL after USERID in SOCKS4 requests

### DIFF
--- a/src/client/legacy/connect/proxy/socks/v4/messages.rs
+++ b/src/client/legacy/connect/proxy/socks/v4/messages.rs
@@ -9,7 +9,7 @@ use std::net::SocketAddrV4;
 /// |  1  |  1  |    2    |         4         |   Variable  |  1   |  Variable  |   1  |
 /// +-----+-----+----+----+----+----+----+----+-------------+------+------------+------+
 ///                                                                ^^^^^^^^^^^^^^^^^^^^^
-///                                                      optional: only do IP is 0.0.0.X
+///                                                      optional: only if IP is 0.0.0.X
 #[derive(Debug)]
 pub struct Request<'a>(pub &'a Address);
 
@@ -41,7 +41,7 @@ impl Request<'_> {
     pub fn write_to_buf<B: BufMut>(&self, mut buf: B) -> Result<usize, SerializeError> {
         match self.0 {
             Address::Socket(socket) => {
-                if buf.remaining_mut() < 10 {
+                if buf.remaining_mut() < 9 {
                     return Err(SerializeError::WouldOverflow);
                 }
 
@@ -51,30 +51,28 @@ impl Request<'_> {
                 buf.put_u16(socket.port()); // Port
                 buf.put_slice(&socket.ip().octets()); // IP
 
-                buf.put_u8(0x00); // USERID
-                buf.put_u8(0x00); // NULL
+                buf.put_u8(0x00); // NULL terminating an empty USERID
 
-                Ok(10)
+                Ok(9)
             }
 
             Address::Domain(domain, port) => {
-                if buf.remaining_mut() < 10 + domain.len() + 1 {
+                if buf.remaining_mut() < 9 + domain.len() + 1 {
                     return Err(SerializeError::WouldOverflow);
                 }
 
                 buf.put_u8(0x04); // Version
                 buf.put_u8(0x01); // CONNECT
 
-                buf.put_u16(*port); // IP
+                buf.put_u16(*port); // Port
                 buf.put_slice(&[0x00, 0x00, 0x00, 0xFF]); // Invalid IP
 
-                buf.put_u8(0x00); // USERID
-                buf.put_u8(0x00); // NULL
+                buf.put_u8(0x00); // NULL terminating an empty USERID
 
                 buf.put_slice(domain.as_bytes()); // Domain
                 buf.put_u8(0x00); // NULL
 
-                Ok(10 + domain.len() + 1)
+                Ok(9 + domain.len() + 1)
             }
         }
     }

--- a/src/client/legacy/connect/proxy/socks/v4/messages.rs
+++ b/src/client/legacy/connect/proxy/socks/v4/messages.rs
@@ -141,8 +141,7 @@ mod test {
             0x01, // command: connect
             0x1F, 0x90, // destination port: 8080
             127, 0, 0, 1,    // destination address: 127.0.0.1
-            0x00, // userid (empty)
-            0x00, // null terminator
+            0x00, // null terminating an empty userid
         ];
 
         let addr = Address::Socket(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8080));
@@ -159,8 +158,7 @@ mod test {
             0x01, // command: connect
             0x1F, 0x90, // destination port: 8080
             0x00, 0x00, 0x00, 0xFF, // invalid IP: signals that a domain follows (SOCKS4a)
-            0x00, // userid (empty)
-            0x00, // null terminator
+            0x00, // null terminating an empty userid
             b'e', b'x', b'a', b'm', b'p', b'l', b'e', b'.', b'c', b'o', b'm', // domain
             0x00, // null terminator
         ];

--- a/tests/proxy.rs
+++ b/tests/proxy.rs
@@ -381,7 +381,7 @@ async fn test_socks_v4_works() {
 
         let [p1, p2] = target_addr.port().to_be_bytes();
         let [ip1, ip2, ip3, ip4] = [127, 0, 0, 1];
-        let message = [4, 0x01, p1, p2, ip1, ip2, ip3, ip4, 0, 0];
+        let message = [4, 0x01, p1, p2, ip1, ip2, ip3, ip4, 0];
         let n = to_client.read(&mut buf).await.expect("read");
         assert_eq!(&buf[..n], message);
 
@@ -416,6 +416,54 @@ async fn test_socks_v4_works() {
     t1.await.expect("task - client");
     t2.await.expect("task - proxy");
     t3.await.expect("task - target");
+}
+
+#[cfg(not(miri))]
+#[tokio::test]
+async fn test_socks_v4a_with_server_resolved_domain_works() {
+    let proxy_tcp = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let proxy_addr = proxy_tcp.local_addr().expect("local_addr");
+    let proxy_dst = format!("http://{proxy_addr}").parse().expect("uri");
+
+    let mut connector = SocksV4::new(proxy_dst, HttpConnector::new());
+
+    // Client
+    //
+    // Will use `SocksV4` to establish a tunnel to a domain name, leaving
+    // resolution to the proxy server (the SOCKS4a extension).
+    let t1 = tokio::spawn(async move {
+        let _conn = connector
+            .call("https://hyper.rs:443".try_into().unwrap())
+            .await
+            .expect("tunnel");
+    });
+
+    // Proxy
+    //
+    // Will receive a SOCKS4a CONNECT command carrying the domain name, and
+    // reply with a success status.
+    let t2 = tokio::spawn(async move {
+        let (mut to_client, _) = proxy_tcp.accept().await.expect("accept");
+        let mut buf = [0u8; 512];
+
+        let host = "hyper.rs";
+        let [p1, p2] = 443u16.to_be_bytes();
+
+        // VN, CD, DSTPORT, DSTIP (0.0.0.x marks a SOCKS4a request), then the
+        // NULL terminating an empty USERID, then the NULL-terminated domain.
+        let mut message = vec![0x04, 0x01, p1, p2, 0x00, 0x00, 0x00, 0xFF, 0x00];
+        message.extend(host.as_bytes());
+        message.push(0x00);
+
+        let n = to_client.read(&mut buf).await.expect("read");
+        assert_eq!(&buf[..n], message);
+
+        let message = [0, 90, p1, p2, 0, 0, 0, 0];
+        to_client.write_all(&message).await.expect("write");
+    });
+
+    t1.await.expect("task - client");
+    t2.await.expect("task - proxy");
 }
 
 #[cfg(not(miri))]


### PR DESCRIPTION
## What's wrong

The SOCKS4 connector writes one byte too many in its CONNECT request.

A SOCKS4 request is an 8-byte header followed by a **user ID** — a variable-length string ended by a single zero byte:

```
VN(1) CD(1) DSTPORT(2) DSTIP(4) USERID(variable) NULL(1)
```

— [_SOCKS: A protocol for TCP proxy across firewalls_](https://www.openssh.com/txt/socks4.protocol), Ying-Da Lee

This connector never sends a user ID, so that field is empty and only its single terminating zero byte belongs on the wire — 9 bytes in total. `Request::write_to_buf` in `src/client/legacy/connect/proxy/socks/v4/messages.rs` wrote _two_ zero bytes (one commented `USERID`, one commented `NULL`), so it sent 10.

## Why it matters

The SOCKS4a extension — the one that lets the _proxy_ resolve a domain name — puts the hostname immediately after that terminator, itself ended by a zero byte:

```
VN(1) CD(1) DSTPORT(2) DSTIP(4) USERID(variable) NULL(1) HOSTNAME(variable) NULL(1)
```

— [_SOCKS 4A: A Simple Extension to SOCKS 4 Protocol_](https://www.openssh.com/txt/socks4a.protocol), Ying-Da Lee

That is this connector's default mode: `local_dns` is off by default, so a domain destination is sent by name for the proxy to resolve. With an extra zero byte in front of it, the proxy reads the hostname field as an empty string, and the real hostname is never part of the request at all.

Feeding both versions of the bytes to a parser that follows the spec literally:

```
SOCKS4a BEFORE (19 bytes): port=443 ip=0.0.0.255 userid="" hostname=""         leftover="hyper.rs\0"
SOCKS4a AFTER  (18 bytes): port=443 ip=0.0.0.255 userid="" hostname="hyper.rs" leftover=""
SOCKS4  BEFORE (10 bytes): port=443 ip=127.0.0.1 userid="" (no hostname)       leftover="\0"
SOCKS4  AFTER  ( 9 bytes): port=443 ip=127.0.0.1 userid="" (no hostname)       leftover=""
```

In other words:

- **SOCKS4a (domain destination — the default) is broken.** The proxy gets an empty hostname and the request fails. Worse, the leftover `hyper.rs\0` stays in the proxy's receive buffer and is relayed into the tunnel as if the client had sent it as application data.
- **Plain SOCKS4 (IPv4 destination) still connects**, because the address travels in DSTIP — but the leftover zero byte is still there and reaches the target as a stray first byte of the tunneled stream.

As an independent check, curl builds the same request with exactly one terminator: in `lib/socks.c` it appends `strlen(user) + 1` bytes for the user ID (just the terminator when there is no user), then `strlen(hostname) + 1` for SOCKS4a.

## The change

- Remove the extra zero byte, and adjust the two `remaining_mut()` checks and the returned lengths from `10` to `9`.
- Add `test_socks_v4a_with_server_resolved_domain_works`. The domain path had no test at all, which is how this went unnoticed since the connectors landed in #187 — the existing `test_socks_v4_works` only covers the IPv4 path, where the bug is much less visible.
- Fix one comment on the line being touched: `buf.put_u16(*port)` was labelled `// IP`.

No public API change; the only behavioural difference is one fewer byte on the wire. `cargo test --all-features --test proxy` passes.
