### PR TITLE
fix(client): spawn background tasks detached from the request span

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,8 @@ tokio = { version = "1", features = ["macros", "test-util", "signal", "net", "io
 tokio-test = "0.4"
 tower-test = "0.4"
 pretty_env_logger = "0.5"
+tracing = "0.1.36"
+tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "std"] }
 
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dev-dependencies]
 pnet_datalink = "0.35.0"

--- a/src/common/exec.rs
+++ b/src/common/exec.rs
@@ -31,7 +31,9 @@ impl Exec {
     {
         match *self {
             Exec::Executor(ref e) => {
-                e.execute(Box::pin(fut));
+                tracing::dispatcher::with_default(&tracing::Dispatch::none(), || {
+                    e.execute(Box::pin(fut));
+                });
             }
         }
     }

--- a/src/common/exec.rs
+++ b/src/common/exec.rs
@@ -31,9 +31,12 @@ impl Exec {
     {
         match *self {
             Exec::Executor(ref e) => {
+                #[cfg(feature = "tracing")]
                 tracing::dispatcher::with_default(&tracing::Dispatch::none(), || {
                     e.execute(Box::pin(fut));
                 });
+                #[cfg(not(feature = "tracing"))]
+                e.execute(Box::pin(fut));
             }
         }
     }

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,6 +1,5 @@
 #![allow(missing_docs)]
 
-#[cfg(feature = "client-legacy")]
 pub(crate) mod exec;
 #[cfg(feature = "client-legacy")]
 mod lazy;

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,5 +1,6 @@
 #![allow(missing_docs)]
 
+#[cfg(feature = "client-legacy")]
 pub(crate) mod exec;
 #[cfg(feature = "client-legacy")]
 mod lazy;

--- a/tests/legacy_client.rs
+++ b/tests/legacy_client.rs
@@ -6,6 +6,8 @@ use std::io::{Read, Write};
 use std::net::{SocketAddr, TcpListener};
 use std::pin::{Pin, pin};
 use std::sync::Arc;
+#[cfg(not(miri))]
+use std::sync::Mutex;
 use std::sync::atomic::Ordering;
 use std::task::Poll;
 use std::thread;
@@ -18,6 +20,12 @@ use futures_util::{self, Stream};
 use http_body_util::BodyExt;
 use http_body_util::{Empty, Full, StreamBody};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
+#[cfg(not(miri))]
+use tracing::Instrument;
+#[cfg(not(miri))]
+use tracing_subscriber::layer::{Context, Layer, SubscriberExt};
+#[cfg(not(miri))]
+use tracing_subscriber::registry::LookupSpan;
 
 use hyper::Request;
 use hyper::body::Bytes;
@@ -149,6 +157,139 @@ async fn drop_client_closes_idle_connections() {
     let t = pin!(tokio::time::sleep(Duration::from_millis(100)).map(|_| panic!("time out")));
     let close = closes.into_future().map(|(opt, _)| opt.expect("closes"));
     future::select(t, close).await;
+    t1.await.unwrap();
+}
+
+#[cfg(not(miri))]
+#[derive(Clone, Default)]
+struct ClosedSpans(Arc<Mutex<Vec<String>>>);
+
+#[cfg(not(miri))]
+impl ClosedSpans {
+    // records the name of every span that closes until the guard is dropped
+    fn record() -> (ClosedSpans, tracing::subscriber::DefaultGuard) {
+        let spans = ClosedSpans::default();
+        let guard =
+            tracing::subscriber::set_default(tracing_subscriber::registry().with(spans.clone()));
+        (spans, guard)
+    }
+
+    fn contains(&self, name: &str) -> bool {
+        self.0.lock().unwrap().iter().any(|span| span == name)
+    }
+}
+
+#[cfg(not(miri))]
+impl<S> Layer<S> for ClosedSpans
+where
+    S: tracing::Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_close(&self, id: tracing::Id, ctx: Context<'_, S>) {
+        let name = ctx.span(&id).unwrap().name();
+        self.0.lock().unwrap().push(name.to_owned());
+    }
+}
+
+#[cfg(not(miri))]
+#[cfg(feature = "http1")]
+#[tokio::test]
+async fn request_span_closes_while_conn_idle() {
+    let _ = pretty_env_logger::try_init();
+
+    let (closed_spans, _guard) = ClosedSpans::record();
+
+    let server = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = server.local_addr().unwrap();
+    let (tx1, rx1) = oneshot::channel();
+
+    let t1 = tokio::spawn(async move {
+        let mut sock = server.accept().await.unwrap().0;
+        let mut buf = [0; 4096];
+        sock.read(&mut buf).await.unwrap();
+        sock.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
+            .await
+            .unwrap();
+        let _ = tx1.send(());
+
+        // prevent this thread from closing until end of test, so the connection
+        // stays open and idle until Client is dropped
+        if let Ok(n) = sock.read(&mut buf).await {
+            assert_eq!(n, 0);
+        }
+    });
+
+    let client = Client::builder(TokioExecutor::new()).build_http::<Empty<Bytes>>();
+    let req = Request::builder()
+        .uri(&*format!("http://{addr}/a"))
+        .body(Empty::<Bytes>::new())
+        .unwrap();
+
+    async {
+        let res = client.request(req).await.unwrap();
+        assert_eq!(res.status(), hyper::StatusCode::OK);
+        res.into_body().collect().await.unwrap();
+    }
+    .instrument(tracing::info_span!("test.request"))
+    .await;
+
+    rx1.await.unwrap();
+
+    // the idle connection must not hold the request's span open
+    assert!(closed_spans.contains("test.request"));
+
+    drop(client);
+    t1.await.unwrap();
+}
+
+#[cfg(not(miri))]
+#[cfg(feature = "http2")]
+#[tokio::test]
+async fn request_span_closes_while_h2_conn_idle() {
+    use http::Response;
+    use hyper::service::service_fn;
+
+    let _ = pretty_env_logger::try_init();
+
+    let (closed_spans, _guard) = ClosedSpans::record();
+
+    let server = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = server.local_addr().unwrap();
+
+    let t1 = tokio::spawn(async move {
+        let stream = TokioIo::new(server.accept().await.unwrap().0);
+        // serves until the Client is dropped at the end of the test
+        let _ = hyper::server::conn::http2::Builder::new(TokioExecutor::new())
+            .serve_connection(
+                stream,
+                service_fn(|_| async {
+                    Ok::<_, hyper::Error>(Response::new(Empty::<Bytes>::new()))
+                }),
+            )
+            .await;
+    });
+
+    // prior knowledge, so the handshake happens on the first request
+    let client = Client::builder(TokioExecutor::new())
+        .http2_only(true)
+        .build_http::<Empty<Bytes>>();
+    let req = Request::builder()
+        .uri(&*format!("http://{addr}/a"))
+        .body(Empty::<Bytes>::new())
+        .unwrap();
+
+    async {
+        let res = client.request(req).await.unwrap();
+        assert_eq!(res.status(), hyper::StatusCode::OK);
+        res.into_body().collect().await.unwrap();
+    }
+    .instrument(tracing::info_span!("test.request"))
+    .await;
+
+    // neither our dispatcher nor the one hyper spawns during the handshake may
+    // hold the request's span open
+    assert!(closed_spans.contains("test.request"));
+
+    drop(client);
     t1.await.unwrap();
 }
 


### PR DESCRIPTION
Fixes hyperium/hyper#3904

While instrumenting tracing for a project my team and I are working on, we stumbled into the same issue reported here:
- https://github.com/hyperium/hyper/issues/3904

Currently, when the `tracing` feature is enabled, `TokioExecutor::execute` calls `.in_current_span()` on every task it spawns, so a task keeps a clone of whatever span was active at the time, and that span can't close until the task drops it.
The legacy client spawns its connection and pool tasks mid request, and they outlive the request, so when the connection ends up back in the pool it still the span of the request that opened it.

Note that this "stuck span" issue only happens once per connection, not per request. If a request picks up an idle connection, nothing gets spawned so nothing takes a clone of its span. You can see this in the examples below, where request 1 leaks the span, whereas requests 2 and 3 do not.

### How to reproduce

I asked Claude to generate a test to reproduce the bug. You can find the source code [here](https://gist.github.com/marsavar/4599c03d140660a5079f461f7fec0eec).

I ran the code against this commit and the `master` branch for both `HTTP/1.1` and `HTTP/2` to ensure the fix works for both. Below is the output for each.

<details>
<summary><b>Current master branch - HTTP/1.1</b></summary>

```
=== HTTP/1.1, pool_idle_timeout = 5s ===
req-1: response received after 456.042µs; span closed: NO - still open
req-2: response received after 132.125µs; span closed: yes (immediately)
req-3: response received after 115.083µs; span closed: yes (immediately)

waiting 5s for the idle connection to be evicted...
--- after idle eviction ---
  req-1: STILL OPEN
  req-2: span closed 974.25µs after start
  req-3: span closed 1.10975ms after start

dropping the Client...
--- after Client drop ---
  req-1: span closed 7.003714042s after start
  req-2: span closed 974.25µs after start
  req-3: span closed 1.10975ms after start
```
</details>

<details>
<summary><b>Current master branch - HTTP/2</b></summary>

```
=== HTTP/2, pool_idle_timeout = 5s ===
req-1: response received after 796.5µs; span closed: NO - still open
req-2: response received after 92.541µs; span closed: yes (immediately)
req-3: response received after 87.417µs; span closed: yes (immediately)

waiting 5s for the idle connection to be evicted...
--- after idle eviction ---
  req-1: STILL OPEN
  req-2: span closed 1.330709ms after start
  req-3: span closed 1.434125ms after start

dropping the Client...
--- after Client drop ---
  req-1: span closed 7.003058959s after start
  req-2: span closed 1.330709ms after start
  req-3: span closed 1.434125ms after start
```
</details>

<details>
<summary><b>This PR - HTTP/1.1</b></summary>

```
=== HTTP/1.1, pool_idle_timeout = 5s ===
req-1: response received after 670.5µs; span closed: yes (immediately)
req-2: response received after 97.167µs; span closed: yes (immediately)
req-3: response received after 83.166µs; span closed: yes (immediately)

waiting 5s for the idle connection to be evicted...
--- after idle eviction ---
  req-1: span closed 1.311916ms after start
  req-2: span closed 1.432958ms after start
  req-3: span closed 1.53475ms after start

dropping the Client...
--- after Client drop ---
  req-1: span closed 1.311916ms after start
  req-2: span closed 1.432958ms after start
  req-3: span closed 1.53475ms after start
```
</details>

<details>
<summary><b>This PR - HTTP/2</b></summary>

```
=== HTTP/2, pool_idle_timeout = 5s ===
req-1: response received after 817.084µs; span closed: yes (immediately)
req-2: response received after 96.5µs; span closed: yes (immediately)
req-3: response received after 88.292µs; span closed: yes (immediately)

waiting 5s for the idle connection to be evicted...
--- after idle eviction ---
  req-1: span closed 1.098875ms after start
  req-2: span closed 1.204459ms after start
  req-3: span closed 1.297917ms after start

dropping the Client...
--- after Client drop ---
  req-1: span closed 1.098875ms after start
  req-2: span closed 1.204459ms after start
  req-3: span closed 1.297917ms after start
```
</details>

- [x] The description, docs, and comments (words meant for humans) are written by a human, not by an LLM. (https://seanmonstar.com/micro/20260729-i-want-your-own-words/)
