### PR TITLE
feat(client): add UnixConnector for Unix domain sockets

### DIFF
--- a/src/client/legacy/connect/mod.rs
+++ b/src/client/legacy/connect/mod.rs
@@ -4,6 +4,8 @@
 //!
 //! - A default [`HttpConnector`][] that does DNS resolution and establishes
 //!   connections over TCP.
+//! - A [`UnixConnector`][] that establishes connections over Unix domain
+//!   sockets (only available on Unix platforms).
 //! - Types to build custom connectors.
 //!
 //! # Connectors
@@ -57,6 +59,7 @@
 //! better starting place to extend from.
 //!
 //! [`HttpConnector`]: HttpConnector
+//! [`UnixConnector`]: UnixConnector
 //! [`Service`]: tower_service::Service
 //! [`Uri`]: ::http::Uri
 //! [`Read`]: hyper::rt::Read
@@ -74,11 +77,15 @@ use ::http::Extensions;
 
 #[cfg(feature = "tokio")]
 pub use self::http::{HttpConnector, HttpInfo};
+#[cfg(all(unix, feature = "tokio"))]
+pub use self::unix::UnixConnector;
 
 #[cfg(feature = "tokio")]
 pub mod dns;
 #[cfg(feature = "tokio")]
 mod http;
+#[cfg(all(unix, feature = "tokio"))]
+mod unix;
 
 pub mod proxy;
 

--- a/src/client/legacy/connect/unix.rs
+++ b/src/client/legacy/connect/unix.rs
@@ -1,0 +1,74 @@
+//! A connector that establishes connections over Unix domain sockets.
+
+use std::fmt;
+use std::future::Future;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use http::Uri;
+use tokio::net::UnixStream;
+use tower_service::Service;
+
+use crate::rt::TokioIo;
+
+/// A connector that always connects to a fixed Unix domain socket path.
+///
+/// The [`Uri`] passed to the connector only used for the `Host` header and request
+/// target. The actual connection is always made to the socket path with which this
+/// connector was created.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use hyper_util::client::legacy::Client;
+/// use hyper_util::client::legacy::connect::UnixConnector;
+/// use hyper_util::rt::TokioExecutor;
+///
+/// let connector = UnixConnector::new("/var/run/httpd.sock");
+/// let client: Client<UnixConnector, String> =
+///     Client::builder(TokioExecutor::new()).build(connector);
+/// ```
+#[derive(Clone)]
+pub struct UnixConnector {
+    path: Arc<Path>,
+}
+
+impl UnixConnector {
+    /// Create a new connector which always connects to the given socket path.
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        Self {
+            path: Arc::from(path.into()),
+        }
+    }
+}
+
+impl fmt::Debug for UnixConnector {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("UnixConnector")
+            .field("path", &self.path)
+            .finish()
+    }
+}
+
+impl Service<Uri> for UnixConnector {
+    type Response = TokioIo<UnixStream>;
+    type Error = io::Error;
+    // We can't "name" an `async` generated future.
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        // This connector is always ready.
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, _: Uri) -> Self::Future {
+        let path = self.path.clone();
+        Box::pin(async move {
+            let stream = UnixStream::connect(&*path).await?;
+            Ok(TokioIo::new(stream))
+        })
+    }
+}

--- a/tests/legacy_client.rs
+++ b/tests/legacy_client.rs
@@ -1500,3 +1500,56 @@ async fn test_successful_connection() {
     // Verify the response status is 200 OK.
     assert_eq!(response.status(), 200);
 }
+
+#[cfg(unix)]
+#[cfg(feature = "http1")]
+#[test]
+fn client_over_unix_socket() {
+    use std::os::unix::net::UnixListener;
+
+    use hyper_util::client::legacy::connect::UnixConnector;
+
+    let _ = pretty_env_logger::try_init();
+
+    let path = std::env::temp_dir().join(format!(
+        "hyper-util-unix-connector-test-{}.sock",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_file(&path);
+    let listener = UnixListener::bind(&path).unwrap();
+
+    let client =
+        Client::builder(TokioExecutor::new()).build::<_, Empty<Bytes>>(UnixConnector::new(&path));
+
+    thread::spawn(move || {
+        let mut sock = listener.accept().unwrap().0;
+        sock.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+        sock.set_write_timeout(Some(Duration::from_secs(5)))
+            .unwrap();
+        let mut buf = [0u8; 4096];
+        let n = sock.read(&mut buf).unwrap();
+        let req = s(&buf[..n]);
+        assert!(req.starts_with("GET /unix HTTP/1.1\r\n"));
+        assert!(req.contains("\r\nhost: localhost\r\n"));
+        sock.write_all(b"HTTP/1.1 200 OK\r\ncontent-length: 5\r\n\r\nhello")
+            .unwrap();
+    });
+
+    let rt = runtime();
+    rt.block_on(async {
+        let res = client
+            .request(
+                Request::builder()
+                    .uri("http://localhost/unix")
+                    .body(Empty::<Bytes>::new())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), 200);
+        let body = res.into_body().collect().await.unwrap().to_bytes();
+        assert_eq!(&body[..], b"hello");
+    });
+
+    std::fs::remove_file(&path).unwrap();
+}


### PR DESCRIPTION
Connector for the legacy Client that always connects to a fixed Unix domain socket path, analogous to HttpConnector for TCP.

Useful for talking to locally running services, special proxies, or tunnels.

Destination Uri is used only for the Host header and request target.

- [x] The description, docs, and comments (words meant for humans) are written by a human, not by an LLM. (https://seanmonstar.com/micro/20260729-i-want-your-own-words/)
